### PR TITLE
Rebase edk2 on edk2-stable202002

### DIFF
--- a/scripts/_build/edk2.sh
+++ b/scripts/_build/edk2.sh
@@ -9,8 +9,8 @@ then
 fi
 UEFIPAYLOAD="$(realpath "$1")"
 
-PACKAGE=CorebootPayloadPkg
-#PACKAGE=UefiPayloadPkg
+#PACKAGE=CorebootPayloadPkg
+PACKAGE=UefiPayloadPkg
 BUILD_TYPE=RELEASE
 #BUILD_TYPE=DEBUG
 TOOLCHAIN=GCC5


### PR DESCRIPTION
Rebase on the latest stable tag of EDK II, switching from CorebootPayloadPkg to the new UefiPayloadPkg.