### PR TITLE
Fix building on Debian

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# TODO: Move this to build scripts that require it on Debian
+PATH="$PATH:/usr/sbin"
+
 if [ -z "$1" ]
 then
   echo "$0 <model>" >&2

--- a/scripts/pxestick.sh
+++ b/scripts/pxestick.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+PATH="$PATH:/usr/sbin"
+
 rm -rf build/pxestick
 mkdir -p build/pxestick
 


### PR DESCRIPTION
Debian does not export `/usr/bin` in `PATH` for users like every other distro so builds fail to find mkfs and parted.

Fixes: #95 