### PR TITLE
README.md: update mention of supported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An open source distribution of firmware utilizing coreboot, EDK2, and System76 firmware applications.
 
-Please note that only the darp6 and galp4 models are officially supported - if you brick your device it will be up to you to restore the current firmware using an external programmer.
+Please note that only the darp6, galp4, lemp9, oryp6 models are officially supported - if you brick your device it will be up to you to restore the current firmware using an external programmer.
 
 If you would like to view schematics for any supported System76 model, please send an email to firmware@system76.com with the subject line Schematics for MODEL, where MODEL is the name of a directory in the models directory, such as darp6.
 


### PR DESCRIPTION
The System76 website mentions these models coming with open firmware, so presumably they count as supported.

Perhaps a table summarizing the status of each port could be helpful...