### PR TITLE
Added libudev-dev for Pop!_OS

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -54,6 +54,7 @@ then
     parted \
     patch \
     sdcc \
+    systemd-devel \
     zlib-devel
 else
   msg "Please add support for your distribution to:"

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -25,6 +25,7 @@ then
     git-lfs \
     gnat \
     libncurses-dev \
+    libudev-dev \
     mtools \
     nasm \
     parted \


### PR DESCRIPTION
My build failed on a Pop!_OS-Live-Stick until I installed `libudev-dev`. I don't remember if it was the firmware-open or the ec build that failed, but ec references deps.sh.