### PR TITLE
Use Intel GOP driver from proprietary BIOS

### DIFF
--- a/models/addw1/IntelGopDriver.efi
+++ b/models/addw1/IntelGopDriver.efi
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71f215edc130135bb27c4bbb4f4f5ee2907caf96e1aed3ebfadedd41a4c21708
-size 72224
+oid sha256:4daf57cae8d2fa98ca9f25454fb24b6297b8d2f5fc52f82acc12ccde353e9c43
+size 71712

--- a/models/addw2/IntelGopDriver.efi
+++ b/models/addw2/IntelGopDriver.efi
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71f215edc130135bb27c4bbb4f4f5ee2907caf96e1aed3ebfadedd41a4c21708
-size 72224
+oid sha256:53e429dc4533080b65098d238b0917e8a722b114537fcb17f4818f61283ae0fe
+size 73216

--- a/models/darp5/IntelGopDriver.efi
+++ b/models/darp5/IntelGopDriver.efi
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71f215edc130135bb27c4bbb4f4f5ee2907caf96e1aed3ebfadedd41a4c21708
-size 72224
+oid sha256:d854f9aff8de8a83cca7b72e23eecad93c7fc4da492a6dd91769ecbc3d8f7802
+size 72128

--- a/models/darp6/IntelGopDriver.efi
+++ b/models/darp6/IntelGopDriver.efi
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71f215edc130135bb27c4bbb4f4f5ee2907caf96e1aed3ebfadedd41a4c21708
-size 72224
+oid sha256:f88575f9ed69f06cb2ff5dd2aa745c603d4ae99f456bd3fd634eb8990f0e0f44
+size 72128

--- a/models/galp3-c/IntelGopDriver.efi
+++ b/models/galp3-c/IntelGopDriver.efi
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71f215edc130135bb27c4bbb4f4f5ee2907caf96e1aed3ebfadedd41a4c21708
-size 72224
+oid sha256:791d43349084d005ffe81a6dde58630dc12daa92a0635c138698cd3bffdcaf63
+size 70272

--- a/models/gaze15/IntelGopDriver.efi
+++ b/models/gaze15/IntelGopDriver.efi
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71f215edc130135bb27c4bbb4f4f5ee2907caf96e1aed3ebfadedd41a4c21708
-size 72224
+oid sha256:e01a6b8a98d6f7f6dab4e02f4ddcf5dc4b8a7c940660121221f5a2820b45bc3e
+size 73120

--- a/models/lemp9/IntelGopDriver.efi
+++ b/models/lemp9/IntelGopDriver.efi
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71f215edc130135bb27c4bbb4f4f5ee2907caf96e1aed3ebfadedd41a4c21708
-size 72224
+oid sha256:a4d6495d57d38f00106d6bf7891a0e50bd5deb950620d0825ceeb7934092e562
+size 72320

--- a/models/oryp5/IntelGopDriver.efi
+++ b/models/oryp5/IntelGopDriver.efi
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71f215edc130135bb27c4bbb4f4f5ee2907caf96e1aed3ebfadedd41a4c21708
-size 72224
+oid sha256:ebfe655edfde77fbb8fe99bb5617701561fe7e333deedc85519a1205a26a637e
+size 71072

--- a/models/oryp6/IntelGopDriver.efi
+++ b/models/oryp6/IntelGopDriver.efi
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71f215edc130135bb27c4bbb4f4f5ee2907caf96e1aed3ebfadedd41a4c21708
-size 72224
+oid sha256:4593b31bcac5161697038d93fa83dc689e68d445accfe2fa5d35aaae23729517
+size 73312


### PR DESCRIPTION
Using the Intel GOP driver from proprietary firmware has resolved some
issues with the lemp10. Use UEFIExtract from UEFITool to extract the GOP
driver from the proprietary firmware for other boards.

    ./UEFIExtract <firmware.rom> 7755CA7B-CA8F-43C5-889B-E1F59A93D575 -o extract

The version we have been using is what is present in gaze14.

Most of the galp models did not have IntelGopDriver in the extract.