### PR TITLE
Extract IntelGopDriver when generating new model data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-build
 backup.rom
+build/
+extract/

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -14,9 +14,10 @@ then
   sudo apt-get install \
     avr-libc \
     avrdude \
-    build-essential \
     bison \
+    build-essential \
     ccache \
+    cmake \
     curl \
     dosfstools \
     flashrom \
@@ -31,6 +32,7 @@ then
     parted \
     python \
     python3-distutils \
+    qt5-default \
     sdcc \
     uuid-dev \
     zlib1g-dev
@@ -42,6 +44,7 @@ then
     avr-gcc \
     avr-libc \
     avrdude \
+    cmake \
     curl \
     dosfstools \
     flashrom \
@@ -53,6 +56,7 @@ then
     ncurses-devel \
     parted \
     patch \
+    qt5-qtbase-devel \
     sdcc \
     systemd-devel \
     zlib-devel

--- a/scripts/extract.sh
+++ b/scripts/extract.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+
+set -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+TOOL_DIR="$SCRIPT_DIR/../tools"
+UEFIEXTRACT_DIR="$TOOL_DIR/UEFITool/UEFIExtract"
+
+# Make sure UEFITool submodule is checked out
+if [ ! -d "$UEFIEXTRACT_DIR" ]
+then
+	pushd "$TOOL_DIR" >/dev/null
+	git submodule update --init UEFITool
+	popd >/dev/null
+fi
+
+# Make sure UEFIExtract is built
+if [ ! -f "$UEFIEXTRACT_DIR/UEFIExtract" ]
+then
+    pushd "$UEFIEXTRACT_DIR" > /dev/null
+    cmake -B . -G "Unix Makefiles" -DCMAKE_CXX_FLAGS="-Os" -DCMAKE_C_FLAGS="-Os"
+    cmake --build .
+    popd > /dev/null
+fi
+
+"$UEFIEXTRACT_DIR/UEFIExtract" "$@"

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -66,10 +66,24 @@ then
     rm -f flashregion_*.bin
 fi
 
-# Get the Video BIOS Table for Intel systems
+# Get the Video BIOS Table and GOP driver for Intel systems
 if sudo [ -e /sys/kernel/debug/dri/0/i915_vbt ]
 then
     sudo cat /sys/kernel/debug/dri/0/i915_vbt > "${MODEL_DIR}/vbt.rom"
+
+    INTEL_GOP_DRIVER_GUID="7755CA7B-CA8F-43C5-889B-E1F59A93D575"
+    EXTRACT_DIR="extract"
+
+    if [ -n "${BIOS_IMAGE}" ]
+    then
+        if "${SCRIPT_DIR}/extract.sh" "${BIOS_IMAGE}" "${INTEL_GOP_DRIVER_GUID}" -o "${EXTRACT_DIR}" > /dev/null
+        then
+            cp -v "$(find "${EXTRACT_DIR}" | grep IntelGopDriver | grep PE32 | grep body.bin)" "${MODEL_DIR}/IntelGopDriver.efi"
+            rm -rf "${EXTRACT_DIR}"
+        else
+            echo "IntelGopDriver not present in firmware image"
+        fi
+    fi
 fi
 
 # XXX: More reliable way to determine if system has an EC?


### PR DESCRIPTION
Update UEFITool to the `new_engine` branch and add a script to build/use UEFIExtract.

Automate extracting the Intel GOP driver when generating data for a new model.