### PR TITLE
scripts/deps.sh: Use os-release(5) to select correct package manager

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -8,8 +8,10 @@ function msg {
 
 trap 'msg "\x1B[31mFailed to install dependencies!"' ERR
 
-if which apt-get > /dev/null
-then
+source /etc/os-release
+
+
+if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
   msg "Installing system build dependencies"
   sudo apt-get install \
     avr-libc \
@@ -36,7 +38,7 @@ then
     sdcc \
     uuid-dev \
     zlib1g-dev
-elif which dnf > /dev/null
+elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
 then
   msg "Installing system build dependencies"
   sudo dnf group install c-development


### PR DESCRIPTION
Fedora has apt packaged, which causes this script to do the wrong
thing if it is installed. Instead of checking for the package manager
binary, use `os-release(5)` data to select the correct package manager
to use.