### PR TITLE
deps: Skip installing Rust if rustup is available

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -80,12 +80,14 @@ curl -sSf https://review.coreboot.org/tools/hooks/commit-msg \
   -o .git/modules/coreboot/hooks/commit-msg && \
   chmod +x .git/modules/coreboot/hooks/commit-msg
 
-msg "Installing Rust"
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-  | sh -s -- -y --default-toolchain nightly
+if ! which rustup &> /dev/null; then
+  msg "Installing Rust"
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain none
 
-msg "Loading Rust environment"
-source ~/.cargo/env
+  msg "Loading Rust environment"
+  source "${HOME}/.cargo/env"
+fi
 
 msg "Installing pinned Rust toolchain"
 rustup toolchain install "$(cat rust-toolchain)"


### PR DESCRIPTION
Saves time and prevents errors with trying to install rustup twice or potentially overriding the user's default toolchain.