### PR TITLE
docs: Add note about IME state on TGL-U

### DIFF
--- a/docs/intel-me.md
+++ b/docs/intel-me.md
@@ -11,6 +11,16 @@ does not support the ME version used on many of our systems. Instead, we [send
 a HECI command][heci_disable] to tell the Intel ME to disable runtime
 components during early boot.
 
+## Tiger Lake-U
+
+Models using TGL-U processors currently leave the IME enabled. TGL-U removes
+support for S3 and requires S0ix. This requires all CPU, PCH, and PCIe devices
+to have ACPI defined low power states. With S0ix, the CPU has numerous states
+for low power, with the lowest being C10. In order to reach this C10 state, the
+IME must report that it is in a low power state. Disabling the ME with the HAP
+bit keeps the CPU in the C8 state. This nearly triples the power usage in S0ix
+suspend, from around 1 watt to around 3 watts.
+
 [wiki]: https://en.wikipedia.org/wiki/Intel_Management_Engine
 [me\_cleaner]: https://github.com/corna/me_cleaner
 [heci_disable]: https://github.com/system76/coreboot/blob/011439cb9196d6a71d394ead8c98dfd8ead325d4/src/soc/intel/cannonlake/me.c#L186


### PR DESCRIPTION
Explain why we ship galp5/lemp10 with the IME enabled.

Info from [Jeremy's response on reddit](https://www.reddit.com/r/System76/comments/k0g971/intel_me_enabled_in_new_lemur_and_galago/gdke4yt/).