### PR TITLE
scripts: Check coreboot config is correct

### DIFF
--- a/scripts/_build/coreboot.sh
+++ b/scripts/_build/coreboot.sh
@@ -17,6 +17,19 @@ pushd coreboot >/dev/null
   fi
   make distclean
   make defconfig KBUILD_DEFCONFIG="${CONFIG}"
+
+  # Ensure config is correct
+  while read line; do
+      if [[ "${line}" =~ "^#" ]] || [[ -z "${line}" ]]; then
+          continue
+      fi
+
+      if ! grep -q "${line}" ".config"; then
+          echo "expected config not found: ${line}" >&2
+          exit 1
+      fi
+  done < "${CONFIG}"
+
   make --jobs="$(nproc)"
   cp -v "build/coreboot.rom" "${COREBOOT}"
 popd >/dev/null


### PR DESCRIPTION
If a board in `models/` does not exist in coreboot, coreboot will emit a warning and select the first available board for the vendor instead.

This may result in building and being able to flash coreboot with an addw1 configuration on another board.