### PR TITLE
scripts: Check coreboot config is correct

### DIFF
--- a/scripts/_build/coreboot.sh
+++ b/scripts/_build/coreboot.sh
@@ -10,6 +10,27 @@ fi
 CONFIG="$(realpath "$1")"
 COREBOOT="$(realpath "$2")"
 
+function check_configs() {
+  local defconfig="$1"
+
+  while read -r line; do
+    if [[ "${line}" =~ ^# ]] || [[ -z "${line}" ]]; then
+      continue
+    fi
+
+    if [[ "${line}" =~ "=n" ]]; then
+      local config="${line//=n/} is not set"
+    else
+      local config="${line}"
+    fi
+
+    if ! grep -q "${config}" ".config"; then
+      echo "expected config not found: '${config}'" >&2
+      exit 1
+    fi
+  done < "${defconfig}"
+}
+
 pushd coreboot >/dev/null
   if [ ! -d util/crossgcc/xgcc ]
   then
@@ -17,6 +38,8 @@ pushd coreboot >/dev/null
   fi
   make distclean
   make defconfig KBUILD_DEFCONFIG="${CONFIG}"
+  check_configs "${CONFIG}"
+
   make --jobs="$(nproc)"
   cp -v "build/coreboot.rom" "${COREBOOT}"
 popd >/dev/null


### PR DESCRIPTION
If a board in models/ does not exist in coreboot, coreboot will emit a warning and select the first available board for the vendor instead.

This may result in building and being able to flash coreboot with an addw1 configuration on another board.

Fixed version of #168.