### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+Changes are identified by the date of the released firmware including them. If
+you are running System76 Open Firmware, opening the boot menu will show this
+date followed by an underscore and a short git revision.
+
+## 2021-03-03
+
+- oryp7: Release of open firmware with System76 EC
+
+## 2021-02-15
+
+- darp7, galp5: Raise HDMI data rate to support 4K@60Hz
+
+## 2021-02-09
+
+- galp5: Fix GPU driver crash in compute graphics mode
+
+## 2021-02-05
+
+- darp7: Fix keyboard scanning glitches
+
+## 2021-01-21
+
+- darp7: Release of open firmware with System76 EC
+
+## 2021-01-19
+
+- Update boot options on device hotplug
+- Add fan toggle key (Fn+1)
+- Clear NVRAM when CMOS battery is removed
+- galp5, lemp10: Fix NVRAM compacting
+
+## 2021-12-15
+
+- galp5: Support variant with NVIDIA GPU
+
+## 2020-12-04
+
+- galp5, lemp10: Release of open firmware with System76 EC
+
+## 2020-10-19
+
+- Support customizing keyboard at runtime
+- Add battery charging thresholds
+- oryp6: Fix smart charger values
+- Prevent wake when lid is closed
+
+## 2020-09-22
+
+- darp6: Release of open firmware with System76 EC
+- darp6: Fix allocation of memory type range registers
+
+## 2020-09-17
+
+- Enable Wake-on-Lan (on supported models)
+- Add ACPI thermal interface
+- Fix ESXi keyboard issue
+
+## 2020-09-03
+
+- addw2: Release of open firmware with System76 EC
+
+## 2020-08-24
+
+- bonw14: Release of open firmware with System76 EC
+
+## 2020-08-13
+
+- Add UEFI TPM2 support
+
+## 2020-08-06
+
+- Enable ACPI backlight
+- Add firmware configuration information
+
+## 2020-07-06
+
+- oryp6: Release of open firmware with System76 EC
+
+## 2020-05-20
+
+- Warn if no bootable media is found
+
+## 2020-05-15
+
+- Enable i2c-hid touchpad interface
+
+## 2020-05-07
+
+- Fix ghost key debouncing
+
+## 2020-05-04
+
+- Improve ghost key handling and reduce key debounce
+
+## 2020-04-23
+
+- Fix duplicate release of key after release of function key
+
+## 2020-04-18
+
+- lemp9: Update fan curve
+
+## 2020-04-09
+
+- lemp9: Release of open firmware with System76 EC
+
+## 2020-02-05
+
+- Use descriptive device names
+- Only show bootable devices
+
+## 2020-01-13
+
+- Fix NVIDIA eGPU issues
+- Iimprove boot order editing
+
+## 2019-10-31
+
+- darp6, galp4: Release of open firmware with proprietary EC

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ seen in the `models/` directory.
 If the device becomes bricked it will require restoring the current firmware
 using an external programmer. See [flashing](./docs/flashing.md) for details.
 
+## Changelog
+
+For a list of important changes please see the [changelog](./CHANGELOG.md).
+
 ### Schematics
 
 System76 customers may request board schematics by sending an email to

--- a/README.md.in
+++ b/README.md.in
@@ -21,6 +21,10 @@ seen in the `models/` directory.
 If the device becomes bricked it will require restoring the current firmware
 using an external programmer. See [flashing](./docs/flashing.md) for details.
 
+## Changelog
+
+For a list of important changes please see the [changelog](./CHANGELOG.md).
+
 ### Schematics
 
 System76 customers may request board schematics by sending an email to


### PR DESCRIPTION
This is built from the changelogs we use to describe firmware updates. I have ensured the earliest date including the change in released firmware is used, and I don't think there are any conflicts where firmware was released after these dates without including the mentioned changes.