### PR TITLE
Convert toolchain file to TOML syntax

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-nightly-2020-07-27
+[toolchain]
+channel = "nightly-2020-07-27"
+components = ["rust-src"]

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -89,11 +89,8 @@ if ! which rustup &> /dev/null; then
   source "${HOME}/.cargo/env"
 fi
 
-msg "Installing pinned Rust toolchain"
-rustup toolchain install "$(cat rust-toolchain)"
-
-msg "Installing source for pinned Rust toolchain"
-rustup component add --toolchain "$(cat rust-toolchain)" rust-src
+msg "Installing pinned Rust toolchain and components"
+rustup show
 
 msg "\x1B[32mSuccessfully installed dependencies"
 echo "Ready to run ./scripts/build.sh [model]" >&2


### PR DESCRIPTION
rustup 1.23.0 (2020-11-27) introduced support for TOML syntax for the
toolchain file. Use this and specify required compoenents.

To ensure you are using a new enough rustup, run:

    rustup self update