### PR TITLE
gaze15: Add ELAN touchpad settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes are identified by the date of the released firmware including them. If
 you are running System76 Open Firmware, opening the boot menu will show this
 date followed by an underscore and a short git revision.
 
+## 2021-03-19
+
+- gaze15: Add ELAN touchpad settings
+
 ## 2021-03-16
 
 - oryp6, oryp7: Fix buzzing at lowest fan speed


### PR DESCRIPTION
This may address https://github.com/system76/firmware-open/issues/129. First functionality of systems with Synaptics touchpad should be verified. Then I will produce USB images for the affected users to try. Includes and requires https://github.com/system76/coreboot/pull/58

**Please provide `dmesg` output before and after installing!**

- Download [gaze15-touchpad.zip](https://github.com/system76/firmware-open/files/6172736/gaze15-touchpad.zip)
- Extract `gaze15-touchpad.img`
- Use Popsicle to flash to a USB drive
- Boot from the USB drive and follow the instructions to flash the firmware