### PR TITLE
Fix USB-C on galp3-c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ date followed by an underscore and a short git revision.
 
 ## 2021-03-19
 
-- darp5, galp3-c, gaze15: Release of open firmware with System76 EC
+- gaze15: Release of open firmware with System76 EC
 - gaze15: Add ELAN touchpad settings
 
 ## 2021-03-16


### PR DESCRIPTION
Update coreboot to pull in changes that fix USB-C on galp3-c.

Remove darp5/galp3-c from the changelog as they have not been released.