### PR TITLE
deps: Remove qt5 and clean up Arch pkgs

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -38,6 +38,7 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
     python3-distutils \
     sdcc \
     uuid-dev \
+    xxd \
     zlib1g-dev
 elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
   sudo dnf group install c-development
@@ -45,6 +46,7 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
     avr-gcc \
     avr-libc \
     avrdude \
+    ccache \
     cmake \
     curl \
     dosfstools \
@@ -60,6 +62,7 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
     patch \
     sdcc \
     systemd-devel \
+    vim-common \
     zlib-devel
 elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
   sudo pacman -S \
@@ -67,6 +70,7 @@ elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
     avr-libc \
     avrdude \
     bison \
+    ccache \
     cmake \
     curl \
     dosfstools \
@@ -83,7 +87,8 @@ elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
     python \
     python-distutils-extra \
     sdcc \
-    systemd-libs
+    systemd-libs \
+    vim
 else
   msg "Unknown system ID: ${ID}"
   msg "Please add support for your distribution to: $0"

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -62,32 +62,28 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
     systemd-devel \
     zlib-devel
 elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
-    sudo pacman -S \
+  sudo pacman -S \
+    avr-gcc \
+    avr-libc \
+    avrdude \
     bison \
     cmake \
     curl \
     dosfstools \
-    flex \
-    mtools \
-    parted \
-    python \
-    gcc-ada \
-    avr-gcc \
-    ncurses \
-    libgudev \
-    python-distutils-extra \
-    avr-libc \
-    avrdude \
-    curl \
-    dosfstools \
     flashrom \
+    flex \
+    gcc-ada \
     git-lfs \
     msr-tools \
     mtools \
     nasm \
+    ncurses \
     parted \
     patch \
-    sdcc
+    python \
+    python-distutils-extra \
+    sdcc \
+    systemd-libs
 else
   msg "Unknown system ID: ${ID}"
   msg "Please add support for your distribution to: $0"

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -36,7 +36,6 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
     parted \
     python \
     python3-distutils \
-    qt5-default \
     sdcc \
     uuid-dev \
     zlib1g-dev
@@ -59,7 +58,6 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
     ncurses-devel \
     parted \
     patch \
-    qt5-qtbase-devel \
     sdcc \
     systemd-devel \
     zlib-devel


### PR DESCRIPTION
Only qmake was needed, not all of qt5-base, but UEFITool/UEFIExtract can be built only requiring CMake.