### PR TITLE
Update EC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changes are identified by the date of the released firmware including them. If
 you are running System76 Open Firmware, opening the boot menu will show this
 date followed by an underscore and a short git revision.
 
+## unreleased
+
+- Improve thermals by syncing CPU and GPU fans
+- Fix keyboard responsiveness when touchpad uses wrong protocol
+
 ## 2021-04-07
 
 - darp7, galp5, lemp10: Update microcode


### PR DESCRIPTION
- Improve thermals by syncing CPU and GPU fans (system76/ec#177)

Previously the fans were run independently, based only on the temperature their component reported. This meant that potentially only one of the fans was cooling the board.

- Fix keyboard responsiveness when touchpad uses wrong protocol (#156)

i8042 will sometimes attempt to configure the touchpad on boot when usb-hid should be used. The keyboard would become unresponsive for ~15 seconds, due to a long timeout (10ms) that blocked. This prevented users from typing in their dm-crypt password.
