### PR TITLE
scripts: Update pkg for python symlink

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -34,7 +34,7 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
     mtools \
     nasm \
     parted \
-    python \
+    python-is-python3 \
     python3-distutils \
     sdcc \
     uuid-dev \


### PR DESCRIPTION
Install `python-is-python3` to provide the `/usr/bin/python` symlink.

Fixes installing dependencies on Pop!_OS 21.10.

Should be checked it still works on 20.04.