### PR TITLE
Update list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ manager:
 - oryp7
 - oryp8
 
-* Not officially release and not completed code
+* Not completed or officially released
 
 Other models may be in development or available without support, and can be
 seen in the `models/` directory.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ manager:
 - oryp7
 - oryp8
 
-* Not completed or officially released
+\* Not completed or officially released 
 
 Other models may be in development or available without support, and can be
 seen in the `models/` directory.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ manager:
 
 - addw2
 - bonw14
+- darp5*
 - darp6
 - darp7
+- galp3-c*
 - galp4
 - galp5
 - gaze15
@@ -22,6 +24,8 @@ manager:
 - oryp6
 - oryp7
 - oryp8
+
+* Not officially release and not completed code
 
 Other models may be in development or available without support, and can be
 seen in the `models/` directory.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@ manager:
 
 - addw2
 - bonw14
-- darp5
 - darp6
 - darp7
-- galp3-c
 - galp4
 - galp5
 - gaze15


### PR DESCRIPTION
This PR does the following:
- It updates the supported model list to follow this page: https://support.system76.com/articles/open-firmware-systems
as Open Firmware is not on the galp3-c or the darp5.