### PR TITLE
build.sh: Set git-describe length

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ fi
 MODEL_DIR="$(realpath "models/${MODEL}")"
 
 DATE="$(git show --format="%cd" --date="format:%Y-%m-%d" --no-patch)"
-REV="$(git describe --always --dirty)"
+REV="$(git describe --always --dirty --abbrev=7)"
 VERSION="${DATE}_${REV}"
 echo "Building '${VERSION}' for '${MODEL}'"
 


### PR DESCRIPTION
Specify `abbrev` to ensure the length of the commit hash is always the same, in case `core.abbrev` is set or the default changes.