### PR TITLE
Remove rustup self argument from scripts/deps.sh

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -116,8 +116,13 @@ curl -sSf https://review.coreboot.org/tools/hooks/commit-msg \
 
 RUSTUP_NEW_INSTALL=0
 if which rustup &> /dev/null; then
-  msg "Updating rustup"
-  rustup self update
+  if [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
+    msg "Updating rustup (pacman)"
+    pacman -S rustup
+  else 
+    msg "Updating rustup (self update)"
+    rustup self update
+  fi
 else
   RUSTUP_NEW_INSTALL=1
   msg "Installing Rust"


### PR DESCRIPTION
On newer archlinux builds of `rustup`, using `rustup self update` results in an error due to self-updates being disabled. This workaround uses pacman to update `rustup` on arch-based distros instead, but still defaults to self-updates through rustup on other distros.

Tested and working on archlinux-2022.05.01 using `rustup-1.24.3-2` (most up-to-date package).