### PR TITLE
gaze17-3060-b: run end of manufacturing on first boot

### DIFF
--- a/models/gaze17-3060-b/me.rom
+++ b/models/gaze17-3060-b/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca097b159907dd81af55cec28e8cf8468c04aaad54ce719b8cfaadf0905f4568
+oid sha256:49d8bcefe90535f48f066542b4fe4c09ce87305320cf59a390a1e01ebebba2e6
 size 4939776


### PR DESCRIPTION
This sets up the FPFs to be committed on the first boot. It does not lock flash descriptor settings, intentionally.