### PR TITLE
Fix deps.sh for Arch

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -102,7 +102,7 @@ curl -sSf https://review.coreboot.org/tools/hooks/commit-msg \
 RUSTUP_NEW_INSTALL=0
 if which rustup &> /dev/null; then
   msg "Updating rustup"
-  rustup self update
+  rustup self update || true
 else
   RUSTUP_NEW_INSTALL=1
   msg "Installing Rust"


### PR DESCRIPTION
sdcc is now required to build, but missing from Arch dependencies. This PR adds it so it compiles on Arch again.

(Well, it still doesn't _really_ compile out of the box due to some GCC 12 related warnings - but that is unrelated; it compiles fine with these deps if you patch out the GCC warnings, though!)
