### PR TITLE
Use coreboot toolchain for building edk2

### DIFF
--- a/scripts/_build/edk2.sh
+++ b/scripts/_build/edk2.sh
@@ -9,11 +9,17 @@ then
 fi
 UEFIPAYLOAD="$(realpath "$1")"
 
-#PACKAGE=CorebootPayloadPkg
 PACKAGE=UefiPayloadPkg
 BUILD_TYPE=RELEASE
 #BUILD_TYPE=DEBUG
-TOOLCHAIN=GCC5
+TOOLCHAIN=COREBOOT
+
+COREBOOT_TOOLS_DEF="${PWD}/coreboot/payloads/external/tianocore/tools_def.txt"
+export GCC_CC_x86_32="${PWD}/coreboot/util/crossgcc/xgcc/bin/i386-elf-gcc"
+export GCC_CC_x86_64="${PWD}/coreboot/util/crossgcc/xgcc/bin/x86_64-elf-gcc"
+export OBJCOPY_x86_32="${PWD}/coreboot/util/crossgcc/xgcc/bin/i386-elf-objcopy"
+export OBJCOPY_x86_64="${PWD}/coreboot/util/crossgcc/xgcc/bin/x86_64-elf-objcopy"
+export NASM_PREFIX="${PWD}/coreboot/util/crossgcc/xgcc/bin/"
 
 # Force use of python3
 export PYTHON_COMMAND=python3
@@ -21,6 +27,7 @@ export PYTHON_COMMAND=python3
 pushd edk2 >/dev/null
   make -C BaseTools --jobs="$(nproc)"
   source edksetup.sh --reconfig
+  cat "${COREBOOT_TOOLS_DEF}" >> Conf/tools_def.txt
 
   build \
     -a IA32 \

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -29,10 +29,8 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
     libudev-dev \
     msr-tools \
     mtools \
-    nasm \
     parted \
     python-is-python3 \
-    python2 \
     python3-distutils \
     uuid-dev \
     zlib1g-dev
@@ -49,12 +47,10 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
     libuuid-devel \
     msr-tools \
     mtools \
-    nasm \
     ncurses-devel \
     parted \
     patch \
     python-unversioned-command \
-    python2 \
     python3 \
     systemd-devel \
     zlib-devel
@@ -71,13 +67,11 @@ elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
     git-lfs \
     msr-tools \
     mtools \
-    nasm \
     ncurses \
     parted \
     patch \
     python \
     python-distutils-extra \
-    python2 \
     systemd-libs
 else
   msg "Unknown system ID: ${ID}"

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -101,7 +101,7 @@ else
   RUSTUP_NEW_INSTALL=1
   msg "Installing Rust"
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain none
+    | sh -s -- -y --default-toolchain stable
 
   msg "Loading Rust environment"
   source "${HOME}/.cargo/env"

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -121,6 +121,12 @@ pushd ec
 ./scripts/deps.sh
 popd
 
+msg "Building coreboot toolchains"
+pushd coreboot
+make crossgcc-i386
+make crossgcc-x64
+popd
+
 if [[ $RUSTUP_NEW_INSTALL = 1 ]]; then
     msg "\x1B[33m>> rustup was just installed. Ensure cargo is on the PATH with:"
     echo -e "    source ~/.cargo/env\n"


### PR DESCRIPTION
This ensures the same version of GCC is used for building coreboot and the payload.

Test:

- Can build any board from an existing checkout that has been updated
- Can build any board on a fresh OS install after running `./scripts/deps.sh`

Resolves: #334
See also: #313