### PR TITLE
Set spipi to new name instead of IP address

### DIFF
--- a/scripts/_spipi.sh
+++ b/scripts/_spipi.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SPIPI=${SPIPI:-"ubuntu@10.17.89.179"}
+SPIPI=${SPIPI:-"system76@spipi.local"}
 
 if [ ! -d "models/${MODEL}" ]
 then


### PR DESCRIPTION
Improved config script so the spipi config file doesn't have
to be updated with the IP address of the raspberry pi.