### PR TITLE
Modify Submodules if caching server is available

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -92,7 +92,9 @@ msg "Downloading GIT LFS artifacts"
 git lfs pull
 
 if [ "$(git remote get-url origin)" == "http://192.168.50.76:3000/system76/firmware-open.git" ]; then
+  used_cache_server=true
   msg "Cloned from local repo. Modifying submodule locations"
+  cp .gitmodules .gitmodules-bkup
   sed -i "s/https:\/\/github.com/http:\/\/192.168.50.76:3000/g" .gitmodules
   sed -i "s/https:\/\/gitlab.redox-os.org/http:\/\/192.168.50.76:3000/g" .gitmodules
   git submodule sync
@@ -100,6 +102,11 @@ fi
 
 msg "Initializing submodules"
 git submodule update --init --recursive --progress
+
+if [ used_cache_server ]; then
+  msg "Cloned from local repo. Restoring .gitmodules file"
+  mv .gitmodules-bkup .gitmodules
+fi
 
 msg "Installing coreboot commit hook"
 curl -sSf https://review.coreboot.org/tools/hooks/commit-msg \

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -11,7 +11,7 @@ function submodule_update_with_cache {
   sed -i "s/https:\/\/gitlab.redox-os.org/http:\/\/192.168.50.76:3000/g" .gitmodules
   sed -i "s/https:\/\/review.coreboot.org/http:\/\/192.168.50.76:3000\/coreboot/g" .gitmodules
   git submodule sync --recursive
-  git submodule update --init --progress --force --remote --jobs 5
+  git submodule update --init --progress --force --remote --jobs 5 --depth 1
   for path in $(find $1 -mindepth 2 -name ".gitmodules"); do
     submodule_update_with_cache "${path//.gitmodules}"
   done
@@ -108,7 +108,7 @@ if [ "${git_origin_url//.git}" == "http://192.168.50.76:3000/system76/firmware-o
   submodule_update_with_cache .
 else
   msg "Initializing submodules"
-  git submodule update --init --recursive --progress
+  git submodule update --init --recursive --progress --jobs 5
 fi
 
 msg "Installing coreboot commit hook"

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -7,11 +7,18 @@ function msg {
 }
 
 function submodule_update_with_cache {
+  echo "$1/.gitmodules"
+  if [[ -f "$1/.gitmodules" ]]; then
+    cd $1
+  else
+    return
+  fi
   sed -i "s/https:\/\/github.com/http:\/\/192.168.50.76:3000/g" .gitmodules
   sed -i "s/https:\/\/gitlab.redox-os.org/http:\/\/192.168.50.76:3000/g" .gitmodules
   sed -i "s/https:\/\/review.coreboot.org/http:\/\/192.168.50.76:3000\/coreboot/g" .gitmodules
   git submodule sync --recursive
-  git submodule update --init --progress --force --remote --jobs 5 --depth 1
+  git submodule update --init --progress --remote --jobs 5
+  echo "find $1 in $(pwd)"
   for path in $(find $1 -mindepth 2 -name ".gitmodules"); do
     submodule_update_with_cache "${path//.gitmodules}"
   done
@@ -105,7 +112,9 @@ git lfs pull
 git_origin_url="$(git remote get-url origin)"
 if [ "${git_origin_url//.git}" == "http://192.168.50.76:3000/system76/firmware-open" ]; then
   msg "Cloned from local repo. Modifying submodule locations"
-  submodule_update_with_cache .
+  wd=$(pwd)
+  submodule_update_with_cache $(pwd)
+  cd $wd
 else
   msg "Initializing submodules"
   git submodule update --init --recursive --progress --jobs 5

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -91,6 +91,13 @@ git lfs install
 msg "Downloading GIT LFS artifacts"
 git lfs pull
 
+if [ "$(git remote get-url origin)" == "http://192.168.50.76:3000/system76/firmware-open.git" ]; then
+  msg "Cloned from local repo. Modifying submodule locations"
+  sed -i "s/https:\/\/github.com/http:\/\/192.168.50.76:3000/g" .gitmodules
+  sed -i "s/https:\/\/gitlab.redox-os.org/http:\/\/192.168.50.76:3000/g" .gitmodules
+  git submodule sync
+fi
+
 msg "Initializing submodules"
 git submodule update --init --recursive --progress
 


### PR DESCRIPTION
System76 has a local git caching server (gitea) to speed up cloning
for QA and engineers. This change checks if the repo was cloned
from the cacheing server, if so, then modify the .gitmodules
file to point at the caching server too, thus speeding up git
submodule updating too.