### PR TITLE
Install deps without confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ date followed by an underscore and a short git revision.
 
 - Updated CSME for TGL-H to 15.0.41.2158
 - Updated CSME for TGL-U to 15.0.41.2158
+- Changed build to use coreboot toolchain for edk2
 
 ## 2022-08-03
 

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -13,7 +13,10 @@ source /etc/os-release
 
 msg "Installing system build dependencies"
 if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
-  sudo apt-get install \
+  sudo apt-get --quiet update
+  sudo apt-get --quiet install \
+    --no-install-recommends \
+    --assume-yes \
     bison \
     build-essential \
     ccache \
@@ -37,6 +40,7 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
 elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
   sudo dnf group install c-development
   sudo dnf install \
+    --assumeyes \
     ccache \
     cmake \
     curl \
@@ -56,6 +60,7 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
     zlib-devel
 elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
   sudo pacman -S \
+    --no-confirm \
     bison \
     ccache \
     cmake \


### PR DESCRIPTION
This makes `dep.sh` usable from CI. Also update the package lists before installing on debian/ubuntu.