### PR TITLE
ec: Fix charger values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ date followed by an underscore and a short git revision.
 ## unreleased
 
 - oryp8: Fixed brightness controls on Windows
+- Fixed smart charger values for all boards
 
 ## 2022-09-07
 


### PR DESCRIPTION
- charger: Limit charger values to max valid value
- charger/bq24780s: Set RSENSE ratio option
- charger/bq24780s: Fix charge current mask
- oryp[5-8]: Reduce charge current to 2A

Requires: system76/ec#303