### PR TITLE
coreboot: Fix ACPI brightness controls on ADL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ Changes are identified by the date of the released firmware including them. If
 you are running System76 Open Firmware, opening the boot menu will show this
 date followed by an underscore and a short git revision.
 
-## 2022-11-02
+## 2022-11-10
 
 - lemp11: Added workaround to force S0ix entry on suspend
 - tgl-u: Removed CPU PCIe RP RTD3 config to fix suspend with certain drives
 - adl-p: Removed CPU PCIe RP RTD3 config to fix suspend with certain drives
+- adl-p: Fixed ACPI brightness controls on Windows 10 and Linux 6.1
 
 ## 2022-10-14
 


### PR DESCRIPTION
Hook up GMA ACPI brightness controls for ADL and set the gfx register for ADL boards.

Fixes backlight controls on Windows 10 and Linux 6.1.

Change approved in: https://github.com/system76/coreboot/pull/147