### PR TITLE
coreboot: Disable SATA DevSlp on S0ix boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ Changes are identified by the date of the released firmware including them. If
 you are running System76 Open Firmware, opening the boot menu will show this
 date followed by an underscore and a short git revision.
 
-## 2022-11-10
+## 2022-11-14
 
 - lemp11: Added workaround to force S0ix entry on suspend
 - tgl-u: Removed CPU PCIe RP RTD3 config to fix suspend with certain drives
 - adl-p: Removed CPU PCIe RP RTD3 config to fix suspend with certain drives
 - adl-p: Fixed ACPI brightness controls on Windows 10 and Linux 6.1
+- adl-p: Disabled SATA DevSlp to fix S0ix entry
+- tgl-u: Disabled SATA DevSlp to fix S0ix entry
 
 ## 2022-10-14
 


### PR DESCRIPTION
After changing EC detection of S0ix from `CPU_C10_GATE#` to `SLP_S0#`, DevSlp blocks S0ix entry. Disable it for now on TGL-U and ADL-P.

Ref: https://github.com/system76/coreboot/pull/148