### PR TITLE
Ask for kernel version for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,7 @@ assignees: []
 - BIOS version: <!-- `cat /sys/class/dmi/id/bios_version` (e.g.: 2021-09-30_14b8a6e)-->
 - EC version: <!-- This will match the BIOS version unless you flashed it separately. -->
 - OS: <!-- e.g.: Pop!_OS 21.10, Fedora 35, Windows 11 -->
+- Kernel: <!-- `uname -r` (e.g.: 6.0.6-76060006-generic) -->
 
 <!-- Briefly describe the problem. -->
 


### PR DESCRIPTION
Issues may depend on changes that happened in the kernel, such as:

- TBT using software CM instead of firmware CM
- TGL GPIO communities changing to match Windows
- Removal of `intel_backlight`
