### PR TITLE
Add warning of risks to 10th Gen and older systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ For a list of important changes please see the [changelog](./CHANGELOG.md).
 
 ## Building
 
+WARNING: 
+As of the Coreboot 4.19 rebase, attempting to build and flash firmware from
+this repository on Intel 10th generation and earlier hardware will render
+the unit unrecoverable without the use of an external flashing tool such as a
+CH341A programmer. 
+
+
+
 Dependencies can be installed with the provided script.
 
 ```


### PR DESCRIPTION
All this PR does is update the build instruction in the repo's README to include a warning regarding attempting to build for and flash 10th Gen and older hardware. It in no way addresses the underlying issue. 

There has been at least one case of someone in the wild attempting the build and flash from current master, and having to recover through external programmer.  As a result I tagged https://github.com/system76/firmware-open/issues/393 as high priority. 

I would consider this PR to meet the minimum requirements -- inform the end user of their risk -- for deprioritizing that issue. 

The phraseology is totally open to modification. The inclusion of information regarding the cause of the breakage is, in part, to enable sufficiently advanced users to find the last completely valid commit in master to build from should they wish to try, without furnishing enough information to enable a less experienced user to attempt it. 