### PR TITLE
scripts: Force submodule checkout

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -91,7 +91,7 @@ msg "Downloading GIT LFS artifacts"
 git lfs pull
 
 msg "Initializing submodules"
-git submodule update --init --recursive --progress
+git submodule update --init --recursive --checkout --progress
 
 msg "Installing coreboot commit hook"
 curl -sSf https://review.coreboot.org/tools/hooks/commit-msg \


### PR DESCRIPTION
Some coreboot submodules have their update strategy set to "none". They will not be cloned/updated unless `--checkout` is specified.

Fixes building after cloning firmware-open and running `deps.sh`.