### PR TITLE
scripts: Version EC separately from SBIOS

### DIFF
--- a/scripts/_build/ec.sh
+++ b/scripts/_build/ec.sh
@@ -16,6 +16,11 @@ while read line; do
 done < "$1"
 
 source "$1"
-make -C ec VERSION="${VERSION}" "${EC_ARGS[@]}" clean
-make -C ec VERSION="${VERSION}" "${EC_ARGS[@]}" -j "$(nproc)"
-cp "ec/build/${BOARD}/${VERSION}/ec.rom" "$2"
+pushd ec >/dev/null
+DATE="$(git show --format="%cs" --no-patch --no-show-signature)"
+REV="$(git describe --always --dirty --abbrev=7)"
+VERSION="${DATE}_${REV}"
+make "${EC_ARGS[@]}" clean
+make "${EC_ARGS[@]}" -j "$(nproc)"
+cp "build/${BOARD}/${VERSION}/ec.rom" "$2"
+popd >/dev/null

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -96,8 +96,7 @@ KERNELVERSION="${VERSION}" \
 # Rebuild EC firmware for System76 EC models
 if [ ! -e  "${MODEL_DIR}/ec.rom" -a -e "${MODEL_DIR}/ec.config" ]
 then
-    env VERSION="${VERSION}" \
-        ./scripts/_build/ec.sh \
+    ./scripts/_build/ec.sh \
         "${MODEL_DIR}/ec.config" \
         "${BUILD}/ec.rom"
 fi


### PR DESCRIPTION
Stop setting the EC version to the SBIOS version so that the EC will use its real version.

Resolves: #434