### PR TITLE
fix (docs): Update link to EC debugging

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -52,8 +52,8 @@ A couple of methods can be used to get debug logging.
 
 This method requires no soldering of board components.
 
-See [Debugging the EC firmware](./ec/doc/debugging.md) for details on setting
-up EC debugging over the parallel port.
+See [Debugging the EC firmware](https://github.com/system76/ec/blob/master/docs/debugging.md)
+for details on setting up EC debugging over the parallel port.
 
 cbmem output can be passed through the EC by enabling the driver in coreboot.
 Uncomment the config in `models/<model>/coreboot.config` to enable logging the


### PR DESCRIPTION
Closes #454.

The full GitHub link won't be seamless with mdBook if https://github.com/system76/firmware-open/pull/383 is merged, but doing some quick web searching, I don't see a way to have a relative link into a submodule file (at least that will work here on GitHub).

The old link seemed to be outdated even if it was being dealt with locally (the directory is currently `docs`, not `doc`).