### PR TITLE
ec: Fix lock up during opportunistic suspend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ features apply to your model and firmware version, see the
 
 ## unreleased
 
+- tgl-u: Fixed potential EC lock up during opportunistic suspend
+
+## 2023-09-19
+
 - rpl-hx: Added support for 5600 MHz RAM
 
 ## 2023-09-08


### PR DESCRIPTION
Fix a potential lock up during S0ix opportunistic suspend, caused by waiting indefinitely for a PECI command to complete when it is not available.