### PR TITLE
coreboot: Fix OZ711LV2 LTR for galp5 3050 variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ features apply to your model and firmware version, see the
 ## unreleased
 
 - tgl-u: Fixed potential EC lock up during opportunistic suspend
+- galp5: Fixed CPU not going lower than C2 due to card reader LTR
 
 ## 2023-09-19
 


### PR DESCRIPTION
Fix programming the LTR so that CPU can reach C-states deeper than C2.