### PR TITLE
scripts: Always set EC build dir

### DIFF
--- a/scripts/_build/ec.sh
+++ b/scripts/_build/ec.sh
@@ -15,6 +15,8 @@ while read line; do
     fi
 done < "$1"
 
-make -C ec clean
-make -C ec VERSION="${VERSION}" "${EC_ARGS[@]}" BUILD=build -j "$(nproc)"
-cp "ec/build/ec.rom" "$2"
+BUILD_DIR="build"
+
+make -C ec BUILD="$BUILD_DIR" clean
+make -C ec VERSION="${VERSION}" "${EC_ARGS[@]}" BUILD="$BUILD_DIR" -j "$(nproc)"
+cp "ec/$BUILD_DIR/ec.rom" "$2"


### PR DESCRIPTION
Building EC was broken as the build output from the previous board was not being cleaned. `BUILD` is now always set, defaulting to "build", instead of only when `BOARD` is specified. For good measure, add it to the clean command in case a custom path is used.

Fixes: 569321f9ac79 ("scripts: Set EC build dir")