### PR TITLE
Split building coreboot toolchains to a separate file

### DIFF
--- a/scripts/_build/coreboot.sh
+++ b/scripts/_build/coreboot.sh
@@ -32,10 +32,6 @@ function check_configs() {
 }
 
 pushd coreboot >/dev/null
-  if [ ! -d util/crossgcc/xgcc ]
-  then
-    make CPUS="$(nproc)" crossgcc-i386
-  fi
   make distclean
   make defconfig KBUILD_DEFCONFIG="${CONFIG}"
   check_configs "${CONFIG}"

--- a/scripts/coreboot-sdk.sh
+++ b/scripts/coreboot-sdk.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Build the coreboot toolchains
+
+# shellcheck disable=SC1091
+
+set -e
+
+. /etc/os-release
+if [ "$ID" = "arch" ] || [[ "$ID_LIKE" =~ "arch" ]]; then
+    sudo pacman -S --noconfirm \
+        bison \
+        bzip2 \
+        ca-certificates \
+        curl \
+        flex \
+        gcc \
+        gcc-ada \
+        make \
+        patch \
+        tar \
+        xz \
+        zlib
+elif [ "$ID" = "fedora" ] || [[ "$ID_LIKE" =~ "fedora" ]]; then
+    sudo dnf install --assumeyes \
+        bison \
+        bzip2 \
+        ca-certificates \
+        curl \
+        flex \
+        gcc \
+        gcc-c++ \
+        gcc-gnat \
+        make \
+        patch \
+        tar \
+        xz \
+        zlib-devel
+elif [ "$ID" = "ubuntu" ] || [[ "$ID_LIKE" =~ "debian" ]]; then
+    sudo apt-get --quiet update
+    sudo apt-get --quiet install --no-install-recommends --assume-yes \
+        bison \
+        bzip2 \
+        ca-certificates \
+        curl \
+        flex \
+        g++ \
+        gcc \
+        gnat \
+        make \
+        patch \
+        tar \
+        xz-utils \
+        zlib1g-dev
+else
+    printf "\e[1;31munsupported host:\e[0m %s\n" "$ID"
+    exit 1
+fi
+
+make -C coreboot CPUS="$(nproc)" crossgcc-i386
+make -C coreboot CPUS="$(nproc)" crossgcc-x64
+make -C coreboot gitconfig

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -11,14 +11,12 @@ trap 'msg "\x1B[31mFailed to install dependencies!"' ERR
 
 source /etc/os-release
 
-
 msg "Installing system build dependencies"
 if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
   sudo apt-get --quiet update
   sudo apt-get --quiet install \
     --no-install-recommends \
     --assume-yes \
-    bison \
     build-essential \
     ccache \
     cmake \
@@ -26,9 +24,7 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
     devmem2 \
     dosfstools \
     flashrom \
-    flex \
     git-lfs \
-    gnat \
     libncurses-dev \
     libudev-dev \
     msr-tools \
@@ -47,7 +43,6 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
     curl \
     dosfstools \
     flashrom \
-    gcc-gnat \
     git-lfs \
     libuuid-devel \
     msr-tools \
@@ -62,14 +57,11 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
 elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
   sudo pacman -S \
     --noconfirm \
-    bison \
     ccache \
     cmake \
     curl \
     dosfstools \
     flashrom \
-    flex \
-    gcc-ada \
     git-lfs \
     msr-tools \
     mtools \
@@ -97,10 +89,8 @@ fi
 msg "Initializing submodules"
 git submodule update --init --recursive --checkout --progress
 
-msg "Installing coreboot commit hook"
-curl -sSf https://review.coreboot.org/tools/hooks/commit-msg \
-  -o .git/modules/coreboot/hooks/commit-msg && \
-  chmod +x .git/modules/coreboot/hooks/commit-msg
+msg "Building coreboot toolchains"
+./scripts/coreboot-sdk.sh
 
 msg "Installing Rust toolchain and components"
 ./scripts/install-rust.sh
@@ -108,12 +98,6 @@ msg "Installing Rust toolchain and components"
 msg "Installing EC dependencies"
 pushd ec
 ./scripts/deps.sh
-popd
-
-msg "Building coreboot toolchains"
-pushd coreboot
-make CPUS="$(nproc)" crossgcc-i386
-make CPUS="$(nproc)" crossgcc-x64
 popd
 
 msg "\x1B[32mSuccessfully installed dependencies"


### PR DESCRIPTION
Specify dependencies specifically for building coreboot toolchains in the file, so they are not conflated with the dependencies required for building firmware-open.

Remove building the toolchain when building firmware, so that the new script is the single source for building coreboot toolchains.