### PR TITLE
Set and use `XGCCPATH`

### DIFF
--- a/scripts/_build/edk2.sh
+++ b/scripts/_build/edk2.sh
@@ -14,12 +14,7 @@ BUILD_TYPE=RELEASE
 #BUILD_TYPE=DEBUG
 TOOLCHAIN=COREBOOT
 
-COREBOOT_TOOLS_DEF="${PWD}/coreboot/payloads/external/edk2/tools_def.txt"
-export GCC_CC_x86_32="${PWD}/coreboot/util/crossgcc/xgcc/bin/i386-elf-gcc"
-export GCC_CC_x86_64="${PWD}/coreboot/util/crossgcc/xgcc/bin/x86_64-elf-gcc"
-export OBJCOPY_x86_32="${PWD}/coreboot/util/crossgcc/xgcc/bin/i386-elf-objcopy"
-export OBJCOPY_x86_64="${PWD}/coreboot/util/crossgcc/xgcc/bin/x86_64-elf-objcopy"
-export NASM_PREFIX="${PWD}/coreboot/util/crossgcc/xgcc/bin/"
+COREBOOT_TOOLS_DEF="$XGCCPATH/../share/edk2config/tools_def.txt"
 
 # Force use of python3
 export PYTHON_COMMAND=python3

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-# TODO: Move this to build scripts that require it on Debian
-PATH="$PATH:/usr/sbin"
+export XGCCPATH="${XGCCPATH:-$PWD/coreboot/util/crossgcc/xgcc/bin}"
+export PATH="$XGCCPATH:$PATH:/usr/sbin"
 
 if [ -z "$1" ]
 then


### PR DESCRIPTION
Allow overriding the coreboot toolchain location with `XGCCPATH` so that xgcc can be installed to a separate location, such as `/opt`.