### PR TITLE
scripts: Address shellcheck issues

### DIFF
--- a/scripts/_build/coreboot.sh
+++ b/scripts/_build/coreboot.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z "$1" -o ! -e "$1" -o -z "$2" ]
+if [ -z "$1" ] || [ ! -e "$1" ] || [ -z "$2" ]
 then
   echo "$0 [coreboot.config] [coreboot.rom]" >&2
   exit 1
@@ -10,7 +10,7 @@ fi
 CONFIG="$(realpath "$1")"
 COREBOOT="$(realpath "$2")"
 
-function check_configs() {
+check_configs() {
   local defconfig="$1"
 
   while read -r line; do

--- a/scripts/_build/ec.sh
+++ b/scripts/_build/ec.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1090
+
 set -e
 
-if [ -z "$1" -o ! -e "$1" -o -z "$2" ]
+if [ -z "$1" ] || [ ! -e "$1" ] || [ -z "$2" ]
 then
     echo "$0 <config> <output>" >&2
     exit 1

--- a/scripts/_build/edk2.sh
+++ b/scripts/_build/edk2.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091
+
 set -e
 
 if [ -z "$1" ]

--- a/scripts/_ch341a.sh
+++ b/scripts/_ch341a.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2034
+
 if [ ! -d "models/${MODEL}" ]
 then
   echo "model '${MODEL}' not found" >&2

--- a/scripts/_spipi.sh
+++ b/scripts/_spipi.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2034
+
 SPIPI=${SPIPI:-"system76@spipi.local"}
 
 if [ ! -d "models/${MODEL}" ]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,7 +46,7 @@ EDK2_ARGS+=(
 )
 
 # Rebuild gop-policy (used by edk2)
-if [ -e "${MODEL_DIR}/IntelGopDriver.inf" -a -e "${MODEL_DIR}/vbt.rom" ]
+if [ -e "${MODEL_DIR}/IntelGopDriver.inf" ] && [ -e "${MODEL_DIR}/vbt.rom" ]
 then
     touch apps/gop-policy/Cargo.toml
     FIRMWARE_OPEN_VBT="${MODEL_DIR}/vbt.rom" \
@@ -84,7 +84,7 @@ KERNELVERSION="${VERSION}" \
         "${COREBOOT}"
 
 # Rebuild EC firmware for System76 EC models
-if [ ! -e  "${MODEL_DIR}/ec.rom" -a -e "${MODEL_DIR}/ec.config" ]
+if [ ! -e  "${MODEL_DIR}/ec.rom" ] && [ -e "${MODEL_DIR}/ec.config" ]
 then
     env VERSION="${VERSION}" \
         ./scripts/_build/ec.sh \

--- a/scripts/ch341a-dump.sh
+++ b/scripts/ch341a-dump.sh
@@ -9,7 +9,7 @@ then
 fi
 MODEL="$1"
 
-source scripts/_ch341a.sh
+. scripts/_ch341a.sh
 
 flashrom -p ch341a_spi -c "${CHIP}" -r build/dump.rom
 

--- a/scripts/ch341a-flash.sh
+++ b/scripts/ch341a-flash.sh
@@ -9,6 +9,6 @@ then
 fi
 MODEL="$1"
 
-source scripts/_ch341a.sh
+. scripts/_ch341a.sh
 
 flashrom -p ch341a_spi -c "${CHIP}" -w "build/${MODEL}/firmware.rom"

--- a/scripts/coreboot-gpio.sh
+++ b/scripts/coreboot-gpio.sh
@@ -33,8 +33,8 @@ do
     do
         parts+=("$part")
     done
-    parts[1]="$(printf '0x%08x' "$((${parts[1]} & 0xfffffffd))")"
-    parts[2]="$(printf '0x%04x' "$((${parts[2]} & 0x00003c00))")"
+    parts[1]="$(printf '0x%08x' "$((parts[1] & 0xfffffffd))")"
+    parts[2]="$(printf '0x%04x' "$((parts[2] & 0x00003c00))")"
 
     case "${parts[1]}" in
         0x0???????)

--- a/scripts/flash.sh
+++ b/scripts/flash.sh
@@ -14,7 +14,6 @@ then
   echo "model '${MODEL}' not found" >&2
   exit 1
 fi
-MODEL_DIR="$(realpath "models/${MODEL}")"
 
 DMI_MODEL="$(cat /sys/class/dmi/id/product_version)"
 if [ "${DMI_MODEL}" != "${MODEL}" ]
@@ -29,7 +28,7 @@ export BASEDIR="system76-firmware-update"
 # Clean build directory
 mkdir -p build
 BUILD="$(realpath "build/${MODEL}")"
-rm -rf "${BUILD}/${BASEDIR}"
+rm -rf "${BUILD:?}/${BASEDIR}"
 mkdir -p "${BUILD}/${BASEDIR}"
 
 # Rebuild and copy firmware-update
@@ -50,7 +49,7 @@ fi
 
 # Locate EFI partition mount path
 EFI_PATH="$(bootctl --print-esp-path)"
-if [ -z "${EFI_PATH}" -o ! -d "${EFI_PATH}" ]
+if [ -z "${EFI_PATH}" ] || [ ! -d "${EFI_PATH}" ]
 then
     echo "EFI system partition '${EFI_PATH}' not found" >&2
     exit 1
@@ -63,7 +62,7 @@ then
     echo "EFI system partition name not found" >&2
     exit 1
 fi
-EFI_PART="$(cat /sys/class/block/${EFI_PART_NAME}/partition)"
+EFI_PART="$(cat "/sys/class/block/${EFI_PART_NAME}/partition")"
 
 # Locate EFI disk
 EFI_DISK=""

--- a/scripts/fsp_params.sh
+++ b/scripts/fsp_params.sh
@@ -28,9 +28,9 @@ do
         count="$(echo "$line" | cut -d '[' -f2 | cut -d ']' -f1)"
         for i in $(seq 0 "$count")
         do
-            if [[ "$i" != "$count" ]]
+            if [ "$i" != "$count" ]
             then
-                echo "DISPLAY_UPD($var[$i]);"
+                echo "DISPLAY_UPD(${var[$i]});"
             fi
         done
     else

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -2,6 +2,8 @@
 #
 # Copyright 2020 System76
 
+# shellcheck disable=SC2024
+
 set -e
 
 SCRIPT_DIR=$(dirname "$0")
@@ -54,8 +56,8 @@ cargo build --release
 sudo target/release/coreboot-collector > "${MODEL_DIR}/coreboot-collector.txt"
 popd
 
-${SCRIPT_DIR}/coreboot-gpio.sh "${MODEL_DIR}/coreboot-collector.txt" > "${MODEL_DIR}/gpio.h"
-${SCRIPT_DIR}/coreboot-hda.sh "${MODEL_DIR}/coreboot-collector.txt" > "${MODEL_DIR}/hda_verb.c"
+"${SCRIPT_DIR}/coreboot-gpio.sh" "${MODEL_DIR}/coreboot-collector.txt" > "${MODEL_DIR}/gpio.h"
+"${SCRIPT_DIR}/coreboot-hda.sh" "${MODEL_DIR}/coreboot-collector.txt" > "${MODEL_DIR}/hda_verb.c"
 
 if [ -n "${BIOS_IMAGE}" ]
 then
@@ -108,4 +110,4 @@ then
     fi
 fi
 
-${SCRIPT_DIR}/readmes.sh
+"${SCRIPT_DIR}/readmes.sh"

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-only
 
+# shellcheck disable=SC1091
+
 set -eE
 
-function msg {
+msg() {
   echo -e "\x1B[1m$*\x1B[0m" >&2
 }
 
 trap 'msg "\x1B[31mFailed to install dependencies!"' ERR
 
-source /etc/os-release
+. /etc/os-release
 
 msg "Installing system build dependencies"
 if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then

--- a/scripts/qemu.sh
+++ b/scripts/qemu.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-# if [ -z "$1" ]
-# then
-#   echo "$0 [model]" >&2
-#   exit 1
-# fi
-# MODEL="$1"
 MODEL="qemu"
-
-if [ ! -d "models/${MODEL}" ]
-then
-  echo "model '${MODEL}' not found" >&2
-  exit 1
-fi
-MODEL_DIR="$(realpath "models/${MODEL}")"
 
 qemu-system-x86_64 \
     -enable-kvm \

--- a/scripts/readmes.sh
+++ b/scripts/readmes.sh
@@ -12,7 +12,7 @@ cargo build --manifest-path "scripts/modeltool/Cargo.toml" --release
 
 MODELTOOL="$(realpath "scripts/modeltool/target/release/modeltool")"
 
-function readme_model {
+readme_model() {
     echo -e "\x1B[1m$1\x1B[0m" >&2
 
     pushd "$1" > /dev/null
@@ -28,7 +28,7 @@ do
     readme_model "${dir%/}"
 done
 
-function readme_line {
+readme_line() {
     echo -e "  \x1B[1m$1\x1B[0m" >&2
 
     name="$(basename "$1")"
@@ -42,7 +42,7 @@ function readme_line {
     fi
 
     submodule="$(git submodule status "$1" 2> /dev/null | cut -d ' ' -f 3 || true)"
-    if [ "$submodule" == "$1" ]
+    if [ "$submodule" = "$1" ]
     then
         # Link to submodule URL
         origin="$(git -C "$1" remote get-url origin)"
@@ -53,7 +53,7 @@ function readme_line {
     fi
 }
 
-function readme_dir {
+readme_dir() {
     echo -e "\x1B[1m$1\x1B[0m" >&2
 
     pushd "$1" > /dev/null

--- a/scripts/realtek-coeffs.sh
+++ b/scripts/realtek-coeffs.sh
@@ -13,7 +13,7 @@ do
 	codec_sys="/sys/class/sound/${codec_id}"
 	vendor="$(cat "${codec_sys}/vendor_name")"
 	chip="$(cat "${codec_sys}/chip_name")"
-	if [ "${vendor}" == "Realtek" ]
+	if [ "${vendor}" = "Realtek" ]
 	then
 		echo "# ${codec_id}: ${vendor} ${chip}"
 
@@ -27,7 +27,7 @@ do
 		do
 			# Set coefficient index
 			index_hex="$(printf "0x%02x\n" "${index}")"
-			hda-verb "${codec}" "${nid}" SET_COEF_INDEX "${index_hex}" &>/dev/null
+			hda-verb "${codec}" "${nid}" SET_COEF_INDEX "${index_hex}" >/dev/null 2>&1
 
 			# Get processing coefficient
 			value="$(hda-verb "${codec}" "${nid}" GET_PROC_COEF 0 2>/dev/null | cut -d " " -f 3)"

--- a/scripts/remotes.sh
+++ b/scripts/remotes.sh
@@ -8,7 +8,7 @@ REMOTES=(
 
 set -e
 
-function git_remote {
+git_remote() {
     echo -e "\x1B[1m$1\x1B[0m"
     pushd "$1" > /dev/null
     if git remote | grep "^$2\$"
@@ -23,5 +23,5 @@ function git_remote {
 
 for remote in "${REMOTES[@]}"
 do
-    git_remote $remote
+    git_remote "$remote"
 done

--- a/scripts/spipi-dump.sh
+++ b/scripts/spipi-dump.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2087
+
 set -e
 
 if [ -z "$1" ]
@@ -9,7 +11,7 @@ then
 fi
 MODEL="$1"
 
-source scripts/_spipi.sh
+. scripts/_spipi.sh
 
 ssh -T "${SPIPI}" <<EOF
 cd firmware

--- a/scripts/spipi-erase.sh
+++ b/scripts/spipi-erase.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2087
+
 set -e
 
 if [ -z "$1" ]
@@ -9,7 +11,7 @@ then
 fi
 MODEL="$1"
 
-source scripts/_spipi.sh
+. scripts/_spipi.sh
 
 ssh -T "${SPIPI}" <<EOF
 cd firmware

--- a/scripts/spipi-flash.sh
+++ b/scripts/spipi-flash.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2087
+
 set -e
 
 if [ -z "$1" ]
@@ -9,7 +11,7 @@ then
 fi
 MODEL="$1"
 
-source scripts/_spipi.sh
+. scripts/_spipi.sh
 
 sftp "${SPIPI}" <<EOF
 cd firmware

--- a/scripts/spipi.sh
+++ b/scripts/spipi.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 sudo flashrom -p linux_spi:dev=/dev/spidev0.0,spispeed=24000 "$@"


### PR DESCRIPTION
Report issues by shell files with:

    git ls-files '*.sh' | xargs shellcheck --exclude=SC2162

Address the following:

- [SC1087](https://www.shellcheck.net/wiki/SC1087): Use braces when expanding arrays
- [SC1091](https://www.shellcheck.net/wiki/SC1091): Not following
- [SC2004](https://www.shellcheck.net/wiki/SC2004): `$`/`${}` is unnecessary on arithmetic variables
- [SC2024](https://www.shellcheck.net/wiki/SC2024): `sudo` doesn't affect redirects
- [SC2034](https://www.shellcheck.net/wiki/SC2034): foo appears unused. Verify it or export it
- [SC2086](https://www.shellcheck.net/wiki/SC2086): Double quote to prevent globbing and word splitting
- [SC2087](https://www.shellcheck.net/wiki/SC2087): Quote `EOF`
- [SC2115](https://www.shellcheck.net/wiki/SC2115): Use `"${var:?}"` to ensure this never expands to `/*`
- [SC2148](https://www.shellcheck.net/wiki/SC2148): Add a shebang

Addresses (at least partially) some POSIX/dash issues:

- [SC2113](https://www.shellcheck.net/wiki/SC2113): `function` keyword is non-standard
- [SC3010](https://www.shellcheck.net/wiki/SC3010): In POSIX sh, `[[` `]]` is undefined
- [SC3014](https://www.shellcheck.net/wiki/SC3014): In POSIX sh, `==` in place of `=` is undefined
- [SC3020](https://www.shellcheck.net/wiki/SC3020): In POSIX sh, `&>` is undefined
- [SC3046](https://www.shellcheck.net/wiki/SC3046): In POSIX sh, `source` in place of `.` is undefined

Does not address:

- [SC2162](https://www.shellcheck.net/wiki/SC2162): `read` without `-r` will mangle backslashes
- Any other POSIX/dash-specific issues
