### PR TITLE
coreboot: Fix LTR for card reader on TGL-U boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ features apply to your model and firmware version, see the
 
 ## unreleased
 
+- tgl-u: Fixed CPU not going lower than C2 due to card reader LTR
+
+## 2023-10-13
+
 - tgl-u: Fixed potential EC lock up during opportunistic suspend
 - galp5: Fixed CPU not going lower than C2 due to card reader LTR
 


### PR DESCRIPTION
Just enable the BayHub driver on everything.

Ref: https://github.com/system76/coreboot/pull/198
Resolves: https://github.com/system76/firmware-open/issues/491