### PR TITLE
coreboot: Fix bonw15, oryp11 speaker output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ features apply to your model and firmware version, see the
 ## unreleased
 
 - tgl-u: Fixed CPU not going lower than C2 due to card reader LTR
+- bonw15: Fixed speaker audio cutting in/out
+- oryp11: Fixed speaker audio cutting in/out
 
 ## 2023-10-13
 


### PR DESCRIPTION
Ref: https://github.com/system76/coreboot/pull/199
Resolves: https://github.com/system76/firmware-open/issues/495