### PR TITLE
darp9: Add SSD RTD3 configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ date followed by an underscore and a short git revision. To see if specific
 features apply to your model and firmware version, see the
 [feature matrix](./FEATURES.md).
 
+## 2024-01-18
+
+- darp9: Added SSD RTD3 configs to fix suspend with some drives
+
 ## 2024-01-10
 
 - darp8: Fixed suspend issue on new boards by switching to S0ix by default


### PR DESCRIPTION
Fixes suspend with the following drives:

- Kingston KC3000 (SKC3000D/4096G)
- Kingston HyperX (SHPM2280P2H/240G)
- Solidigm P44 Pro (SSDPFKKW010X7)

Ref: system76/coreboot#192