### PR TITLE
Remove VBT binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.rom filter=lfs diff=lfs merge=lfs -text
 *.fd filter=lfs diff=lfs merge=lfs -text
 *.pdf filter=lfs diff=lfs merge=lfs -text
+*.vbt filter=lfs diff=lfs merge=lfs -text

--- a/models/addw1/vbt.rom
+++ b/models/addw1/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0955bc580d740743dc168a8e3503262e71be605f6acc1f69fde07d3c12bf43ae
-size 6144

--- a/models/addw2/vbt.rom
+++ b/models/addw2/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0955bc580d740743dc168a8e3503262e71be605f6acc1f69fde07d3c12bf43ae
-size 6144

--- a/models/addw3/vbt.rom
+++ b/models/addw3/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee8cd1683aab4af0a704c01ad29ed896d1f61573308a56600f5fe051a84cb8d9
-size 8704

--- a/models/bonw15/vbt.rom
+++ b/models/bonw15/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00440018862cca9866a1882950f395c49fccd102498d49c25b6c3ce11c07183e
-size 8704

--- a/models/darp5/vbt.rom
+++ b/models/darp5/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f04ba76b34aeb7e99e61b51bb4af64731b0aed1ca1c75284c029461e4eca47dd
-size 4608

--- a/models/darp6/vbt.rom
+++ b/models/darp6/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80503c6909e370a424f046fe7866c52b0762db7250b3619c3ae36a800967234b
-size 4608

--- a/models/darp7/vbt.rom
+++ b/models/darp7/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3299823090e748842e46ea914ed3c2f17f133332488a699f87d1454648d95619
-size 8704

--- a/models/darp8/vbt.rom
+++ b/models/darp8/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39eb600e61391472d45da2cca545848ebcc99a426b40b05f7b779c6070f1d228
-size 8704

--- a/models/darp9/vbt.rom
+++ b/models/darp9/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c443698ac38fb3b2a42b59442440ec315c7ffbd2ecfde809e4ee6b57188b5c5
-size 9216

--- a/models/galp2/vbt.rom
+++ b/models/galp2/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b7c95db633e1a9409ce5ad3c2ee8545e1a79851562fa75fc50326aa9ff007d3
-size 4608

--- a/models/galp3-b/vbt.rom
+++ b/models/galp3-b/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c13212baaca2786a5d1025462b7a8a1de8d303a7f1bf1f8eed06079d0f44a80
-size 4608

--- a/models/galp3-c/vbt.rom
+++ b/models/galp3-c/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f04ba76b34aeb7e99e61b51bb4af64731b0aed1ca1c75284c029461e4eca47dd
-size 4608

--- a/models/galp3/vbt.rom
+++ b/models/galp3/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0446f851c4fb38b6c6076f1e6e30b6f6fcb939d52aaf0a30a9c5a608558d25fa
-size 4608

--- a/models/galp4/vbt.rom
+++ b/models/galp4/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d4277e8b84d992c6a801bc32aad326aff3383cb061bae75a1bf3fa3776ff6b2
-size 4608

--- a/models/galp5/vbt.rom
+++ b/models/galp5/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3299823090e748842e46ea914ed3c2f17f133332488a699f87d1454648d95619
-size 8704

--- a/models/galp6/vbt.rom
+++ b/models/galp6/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b83983940fe0894289d69d6ef675ca6fcc3362e51550e156a5e63589659574c
-size 8704

--- a/models/galp7/vbt.rom
+++ b/models/galp7/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0c6ef357fe483f04c53b1abc7c72eef41ab5774e6a21cdd3ea71f10adb670fa
-size 9216

--- a/models/gaze14_1650/vbt.rom
+++ b/models/gaze14_1650/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed3e3d302f33784e3b3eb7f6832e252d50c5da2d3810332a2b2e575ee53f094d
-size 4608

--- a/models/gaze14_1660ti/vbt.rom
+++ b/models/gaze14_1660ti/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed3e3d302f33784e3b3eb7f6832e252d50c5da2d3810332a2b2e575ee53f094d
-size 4608

--- a/models/gaze15/vbt.rom
+++ b/models/gaze15/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f1ef8bb421907492b0d1638c65cdfc37a6be24577b933c971af3dd8a75616b2a
-size 6144

--- a/models/gaze16-3050/vbt.rom
+++ b/models/gaze16-3050/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af15dc53068c9c97ae67ea6f6a5a1b7c68be004a0ce971b758f98685955a9138
-size 8704

--- a/models/gaze16-3060-b/vbt.rom
+++ b/models/gaze16-3060-b/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ffdae6b3d3b64d94aed487f8205ddbf0e9ffdc04245370cd4475608ace5fe2e7
-size 8704

--- a/models/gaze16-3060/vbt.rom
+++ b/models/gaze16-3060/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ffdae6b3d3b64d94aed487f8205ddbf0e9ffdc04245370cd4475608ace5fe2e7
-size 8704

--- a/models/gaze17-3050/vbt.rom
+++ b/models/gaze17-3050/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c9461cd344d08f516017f67e63e116d8875fcf9ee6bab66619855e3545b70b3
-size 8704

--- a/models/gaze17-3060-b/vbt.rom
+++ b/models/gaze17-3060-b/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:19f672aa8d9a41b04d92a69b81f80e084e8ed70157fa68e4a77243118d61e434
-size 8704

--- a/models/gaze18/vbt.rom
+++ b/models/gaze18/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3fd6347901a3b6d10a484688c90e6a3e2e32079bbebab5fadf8a19726935aa37
-size 9216

--- a/models/lemp10/vbt.rom
+++ b/models/lemp10/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d66a84831f8675d7052b37c7943cae0f5475d50f11ec726814e8b5e7caa6659
-size 8704

--- a/models/lemp11/vbt.rom
+++ b/models/lemp11/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70a3e49da120a753a0df0006d5fa57679908407f842346752424ddcf8d8b5fe2
-size 8704

--- a/models/lemp12/vbt.rom
+++ b/models/lemp12/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08e10e17cf0a85e916c42a0a2088ca9841c325c19cdfe3cfa92e60a979ff249f
-size 9216

--- a/models/lemp9/vbt.rom
+++ b/models/lemp9/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80503c6909e370a424f046fe7866c52b0762db7250b3619c3ae36a800967234b
-size 4608

--- a/models/oryp10/vbt.rom
+++ b/models/oryp10/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4c97f4965f5f76f2530d70982ed5a457071f2a525c3240430a5b5efc973890f
-size 8704

--- a/models/oryp11/vbt.rom
+++ b/models/oryp11/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b29b6e75847cfb06e440a5559e8c71b113228a0fa4d07e7da005c1f3ea0f2859
-size 9216

--- a/models/oryp5/vbt.rom
+++ b/models/oryp5/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4441e1cf463cdc9c1070ae3b9f98cc762a103e2bf382c953d3eef4cb57acb906
-size 6144

--- a/models/oryp6/vbt.rom
+++ b/models/oryp6/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4441e1cf463cdc9c1070ae3b9f98cc762a103e2bf382c953d3eef4cb57acb906
-size 6144

--- a/models/oryp7/vbt.rom
+++ b/models/oryp7/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcc66d2e4125fa301db708309990a0f42074dbf103eaa18335013c08fcd32b8e
-size 6144

--- a/models/oryp8/vbt.rom
+++ b/models/oryp8/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9acdf25e90fc858a02a861e73eb0bfde7d5abbcbfcd9564cb6c752caa467c7d0
-size 8704

--- a/models/oryp9/vbt.rom
+++ b/models/oryp9/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bdd06a0a711bae91c5d77be0b0a5197835d32f97bc084242bbe258e734ad156a
-size 8704

--- a/models/serw13/vbt.rom
+++ b/models/serw13/vbt.rom
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70ac6f75c096e59d1026f721040bc46e29a7f449c096878f677d1de977226362
-size 8704

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -73,7 +73,7 @@ fi
 # Get the Video BIOS Table and GOP driver for Intel systems
 if sudo [ -e /sys/kernel/debug/dri/0/i915_vbt ]
 then
-    sudo cat /sys/kernel/debug/dri/0/i915_vbt > "${MODEL_DIR}/vbt.rom"
+    sudo cat /sys/kernel/debug/dri/0/i915_vbt > "${MODEL_DIR}/data.vbt"
 
     INTEL_GOP_DRIVER_GUID="7755CA7B-CA8F-43C5-889B-E1F59A93D575"
     EXTRACT_DIR="extract"


### PR DESCRIPTION
The VBT for every board is already part of coreboot. It is not needed here since at least commit 5b4dbd9c534d ("coreboot: Rebase on 4.15").


Additionally, extract the VBT as `data.vbt` as this is the default file name used by the coreboot config `INTEL_GMA_VBT_FILE`.