### PR TITLE
docs: Update CSME note about S0ix/TGL-U

### DIFF
--- a/docs/intel-me.md
+++ b/docs/intel-me.md
@@ -55,15 +55,18 @@ ME: Current Operation Mode      : 0
 ME: Error Code                  : 0
 ```
 
-## Tiger Lake-U
+## S0ix
 
-Models using TGL-U processors default to having the IME enabled. TGL-U removes
-support for S3 and requires S0ix. This requires all CPU, PCH, and PCIe devices
-to have ACPI defined low power states. With S0ix, the CPU has numerous states
-for low power, with the lowest being C10. In order to reach this C10 state, the
-IME must report that it is in a low power state. Disabling the ME with the HAP
-bit keeps the CPU in the C8 state. This nearly triples the power usage in S0ix
-suspend, from around 1 watt to around 3 watts.
+S0ix (Modern Standby, s2idle) requires all CPU, PCH, and PCIe devices to have
+ACPI defined low power states. The CPU has numerous states for low power, with
+the lowest being C10. In order to reach this C10 state, the CSME must report
+that it is in a low power state.
+
+Disabling the CSME with the HAP bit or HECI command keeps the CPU in the C8
+state. This nearly triples the power usage in S0ix suspend, from around 1 watt
+to around 3 watts.
+
+TGL-U removed support for S3 and requires S0ix.
 
 
 [wiki]: https://en.wikipedia.org/wiki/Intel_Management_Engine


### PR DESCRIPTION
CSME should be enabled when S0ix is used for power savings during suspend. TGL-U is just one case where we default as our TGL-U models do not support S3. Other models may use S0ix as well, such as darp8 and darp9 due to new batches just not working with S3 anymore [1].

[1]: https://github.com/system76/firmware-open/issues/507