### PR TITLE
Add opensuse support

### DIFF
--- a/scripts/coreboot-sdk.sh
+++ b/scripts/coreboot-sdk.sh
@@ -39,6 +39,20 @@ elif [ "$ID" = "fedora" ] || [[ "$ID_LIKE" =~ "fedora" ]]; then
         tar \
         xz \
         zlib-devel
+elif [[ "$ID" =~ "opensuse" ]] || [[ "ID_LIKE" =~ "opensuse" ]]; then
+  sudo zypper in -y \
+    bzip2 \
+    ca-certificates \
+    flex \
+    gcc \
+    gcc-c++ \
+    gcc-ada \
+    make \
+    mozilla-nss-devel \
+    patch \
+    tar \
+    xz \
+    zlib-devel
 elif [ "$ID" = "ubuntu" ] || [[ "$ID_LIKE" =~ "debian" ]]; then
     sudo apt-get --quiet update
     sudo apt-get --quiet install --no-install-recommends --assume-yes \

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -53,6 +53,24 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
     python3 \
     systemd-devel \
     zlib-devel
+elif [[ "${ID}" =~ "opensuse" ]] || [[ "${ID_LIKE}" =~ "opensuse" ]]; then
+  sudo zypper in -t pattern devel_C_C++
+  sudo zypper in \
+    -y \
+    ccache \
+    cmake \
+    curl \
+    dosfstools \
+    flashrom \
+    libuuid-devel \
+    mtools \
+    ncurses-devel \
+    parted \
+    patch \
+    systemd-devel \
+    zlib-devel \
+    python3 \
+    git-lfs
 elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
   sudo pacman -S \
     --noconfirm \

--- a/scripts/install-rust.sh
+++ b/scripts/install-rust.sh
@@ -8,11 +8,17 @@
 
 set -Ee
 
+. /etc/os-release
+
 RUSTUP_NEW_INSTALL=0
 
 # NOTE: rustup is used to allow multiple toolchain installations.
 if command -v rustup >/dev/null 2>&1; then
-    rustup self update
+    if [[ "$ID" =~ "opensuse" ]] || [[ "$ID_LIKE" =~ "opensuse" ]]; then
+      sudo zypper up rustup
+    else
+      rustup self update
+    fi
 else
     RUSTUP_NEW_INSTALL=1
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \


### PR DESCRIPTION
Adds opensuse support in the build scripts. I should've just done the build in a distrobox, but I forgot, and ended up just adding support, so I figured I might as well share :)

Here's the necessary patch to `ec` for its script, too (github won't allow me to attach the patch file):

```patch
From ff99cdae2795fa7c655ceb230eabbd79dcecfedf Mon Sep 17 00:00:00 2001
From: Alexis Purslane <alexispurslane@pm.me>
Date: Tue, 5 Mar 2024 08:15:05 -0500
Subject: [PATCH] Add opensuse support

---
 scripts/deps.sh | 20 +++++++++++++++++++-
 1 file changed, 19 insertions(+), 1 deletion(-)

diff --git a/scripts/deps.sh b/scripts/deps.sh
index 43cba75..914f95d 100755
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -31,6 +31,20 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
         sdcc \
         shellcheck \
         xxd
+elif [[ "${ID}" =~ "opensuse" ]] || [[ "${ID_LIKE}" =~ "opensuse" ]]; then
+    sudo zypper in \
+        -y \
+        cross-avr-gcc13 \
+        avr-libc \
+        avrdude \
+        clang-tools \
+        curl \
+        gcc \
+        make \
+        sdcc \
+        ShellCheck \
+        systemd-devel \
+        vim
 elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
     sudo dnf install \
         --assumeyes \
@@ -75,7 +89,11 @@ make git-config
 RUSTUP_NEW_INSTALL=0
 if which rustup &> /dev/null; then
     msg "Updating rustup"
-    rustup self update
+    if [[ "$ID" =~ "opensuse" ]] || [[ "$ID_LIKE" =~ "opensuse" ]]; then
+      sudo zypper up rustup
+    else
+      rustup self update
+    fi
 else
     RUSTUP_NEW_INSTALL=1
     msg "Installing Rust"
-- 
2.44.0
```