### PR TITLE
scripts: Remove explicit rustup self update

### DIFF
--- a/scripts/install-rust.sh
+++ b/scripts/install-rust.sh
@@ -11,9 +11,7 @@ set -Ee
 RUSTUP_NEW_INSTALL=0
 
 # NOTE: rustup is used to allow multiple toolchain installations.
-if command -v rustup >/dev/null 2>&1; then
-    rustup self update
-else
+if ! command -v rustup >/dev/null 2>&1; then
     RUSTUP_NEW_INSTALL=1
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable


### PR DESCRIPTION
Commit 7d6a15e63c95 ("Convert toolchain file to TOML syntax") switched from the bare toolchain file to the TOML-based one for better management of the toolchain and components used.

Commit cf7fc2c540d5 ("scripts: Update rustup or inform user of env vars") added an explicit `rustup self update` because there were still cases, a year later, of people not having a rustup new enough to support the TOML-based toolchain file.

Now 2 years after that, it should be safe to drop the explicit self update. The TOML format has widespread adoption and rustup now self updates by default. This should allow distro-provided rustup, which disables the self update feature, to work if it is already installed in place of the one downloaded from https://rustup.rs.