### PR TITLE
Add Debian and Fedora dependencies

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -27,8 +27,8 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
     flashrom \
     git-lfs \
     libncurses-dev \
-    libudev-dev \
     libssl-dev \
+    libudev-dev \
     mtools \
     parted \
     pkg-config \

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -31,7 +31,7 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
     libudev-dev \
     mtools \
     parted \
-    pkg-config \
+    pkgconf \
     python-is-python3 \
     python3-distutils \
     uuid-dev \

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -28,8 +28,10 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
     git-lfs \
     libncurses-dev \
     libudev-dev \
+    libssl-dev \
     mtools \
     parted \
+    pkg-config \
     python-is-python3 \
     python3-distutils \
     uuid-dev \
@@ -47,6 +49,7 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
     libuuid-devel \
     mtools \
     ncurses-devel \
+    openssl-devel \
     parted \
     patch \
     python-unversioned-command \


### PR DESCRIPTION
It looks like attempting to build firmware on a clean Pop-OS 22.04 or Fedora 39 install requires additional dependencies not furnished by our install scripts.

This adds those dependencies in correct alphabetical location within their respective parts of the dependencies script. 
- `libssl-dev` and ~~`pkg-config`~~ `pkgconf` for Pop-OS 
- `openssl-devel` for Fedora

I saw no issues with the Arch dependencies in brief testing.