### PR TITLE
coreboot: Fix CMOS options checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ features apply to your model and firmware version, see the
 
 ## unreleased
 
+- Fixed CMOS options not working due to invalid checksum
+
+## 2024-03-25
+
 - lemp13: Added initial release of open firmware with System76 EC
+
+## 2024-03-21
+
 - oryp12: Added initial release of open firmware with System76 EC
 
 ## 2024-03-11


### PR DESCRIPTION
Caching ramtop does not update the checksum, causing CMOS options to not work. Fixes CSME not being disabled on first boot.