### PR TITLE
cml-h: Update CSME to 14.1.74.2355v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ features apply to your model and firmware version, see the
 - Fixed unlock prompt showing when system is already unlocked
 - lemp13-b: Added support for units with 5600 MT/s soldered RAM
 - cml-h: Updated CSME to 14.1.74.2355v6 (14.1.72.2287)
+- cml-u: Updated CSME to 14.1.74.2355v6 (14.1.74.2373)
 
 ## 2024-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ features apply to your model and firmware version, see the
 - tgl: Updated CSME to 15.0.49.2573
 - Fixed unlock prompt showing when system is already unlocked
 - lemp13-b: Added support for units with 5600 MT/s soldered RAM
+- cml-h: Updated CSME to 14.1.74.2355v6 (14.1.72.2287)
 
 ## 2024-05-28
 

--- a/models/addw2/README.md
+++ b/models/addw2/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/addw2
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.72.2287

--- a/models/addw2/me.rom
+++ b/models/addw2/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b8f78c329b72e16c9ae369cb5bcd3ee92807f08986c5ae7a2c33f9caa351cb9
+oid sha256:a52b89126eb60d643cf776c07de3e4ffb43ccf4f152286a0ef0fc0dc6bde3a15
 size 4190208

--- a/models/bonw14/README.md
+++ b/models/bonw14/README.md
@@ -9,4 +9,4 @@
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.72.2287

--- a/models/bonw14/me.rom
+++ b/models/bonw14/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:17247bff1cde3b9a543fbf0b9511fdc8d900f2e8c264bf7ab5f43fa0cc5b42e6
+oid sha256:cce261b1f98814ecf29758ac03e2faeaa49e89caee9c269c3d0b902bc093e3bc
 size 4190208

--- a/models/darp6/README.md
+++ b/models/darp6/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/darp6
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.74.2373

--- a/models/darp6/me.rom
+++ b/models/darp6/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bb8ca44af9bd812478cadbe0ef7a1175d9426de57320679f3475a07f3fa7ab9
+oid sha256:d242789ceeae275b429853b9d23c46fe1f581dd3a93d12815be9dde5e5bd0570
 size 4190208

--- a/models/galp4/README.md
+++ b/models/galp4/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/galp4
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.74.2373

--- a/models/galp4/me.rom
+++ b/models/galp4/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b54e9d1579c53c656c89c57360518cf6f8b07680e8639b65e10cb1af4a33af8
+oid sha256:bcba2088fc1ef63cc7d1e0c907642717bd727ae4d4e26c274c84ada9a48cdfe9
 size 4190208

--- a/models/gaze15/README.md
+++ b/models/gaze15/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/gaze15
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.72.2287

--- a/models/gaze15/me.rom
+++ b/models/gaze15/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b88526bc50f7fafb17975d94c97392bb2aeda626a170e4cf9c149405822f777a
+oid sha256:0e6948c011e8a27849c8bf70e95cd36038b6b2dd4ac83e7be8d5aef36761ff76
 size 4190208

--- a/models/lemp9/README.md
+++ b/models/lemp9/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/lemp9
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.74.2373

--- a/models/lemp9/me.rom
+++ b/models/lemp9/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e439f76d53ab69b801bfaf54b4ee81005e0c577cd6e116bdb2b4893a2d00547
+oid sha256:7814ba36644fe26c98dbf366febf11bd637cd52484f75288f725d85f462d70a8
 size 4190208

--- a/models/oryp6/README.md
+++ b/models/oryp6/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/oryp6
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.72.2287

--- a/models/oryp6/me.rom
+++ b/models/oryp6/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a90896021efc58b41066a25c955d9dd936f42746929e07d49a93cf044e63e30
+oid sha256:4fa6c0bc46cfc04cd670c8e7e150e486d5f8926a377913d09e1474ae807c5ffa
 size 4190208

--- a/models/oryp7/README.md
+++ b/models/oryp7/README.md
@@ -9,4 +9,4 @@
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.72.2287

--- a/models/oryp7/me.rom
+++ b/models/oryp7/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d99df53b08eff08de4917e7037a2b266d5bdaedb136a8aa1f31377ae36050ab
+oid sha256:0e48c60a53e02523d2a439a01502b593b253238960ab26dacf077dfe8bb77faa
 size 4190208


### PR DESCRIPTION
Update CSME to the version from CML-S/H BKC IPU 2024.3 (Kit 817210).

Test:

- CSME can be enabled/disabled via coreboot CMOS option
- System boots
- System completes suspend cycle
- System powers off when shutdown