### PR TITLE
cfl-h: Update CSME to 12.0.94.2380v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ features apply to your model and firmware version, see the
 - Reverted unlock prompt change to restore intended behavior
 - darp10: Fixed reporting of the second fan
 - whl-u: Updated CSME to 12.0.95.2489v2 (12.0.94.2428)
+- cfl: Updated CSME to 12.0.94.2380v9 (12.0.94.2428)
 
 ## 2024-07-01
 

--- a/models/addw1/README.md
+++ b/models/addw1/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/addw1
   - HAP: false
 - [ME](./me.rom)
   - Size: 6140 KB
-  - Version: 12.0.85.1919
+  - Version: 12.0.94.2428

--- a/models/addw1/me.rom
+++ b/models/addw1/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a8e0612f09f79f78204ea6fee2ee537b033d5714a2c1afd2a7c0fa14a2c22db
+oid sha256:624cb9da62dc8202b37c23686532ae0fd2148085e12773e014bffccc82138bb9
 size 6287360

--- a/models/gaze14_1660ti/README.md
+++ b/models/gaze14_1660ti/README.md
@@ -13,4 +13,4 @@ https://system76.com/guides/gaze14
   - HAP: false
 - [ME](./me.rom)
   - Size: 6140 KB
-  - Version: 12.0.85.1919
+  - Version: 12.0.94.2428

--- a/models/gaze14_1660ti/me.rom
+++ b/models/gaze14_1660ti/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ba66b676b1de79ca0dc7b9344d8ad4285d2871fd21b291698f9a007b30486ec
+oid sha256:06e4bfd66f406206a9850cdb2785dc7c15ae377f8949f4fbb67f2c439664c182
 size 6287360

--- a/models/oryp5/README.md
+++ b/models/oryp5/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/oryp5
   - HAP: false
 - [ME](./me.rom)
   - Size: 6140 KB
-  - Version: 12.0.85.1919
+  - Version: 12.0.94.2428

--- a/models/oryp5/me.rom
+++ b/models/oryp5/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3a354b3d701e61c8398456582e5db83ea82b2e32603f189cfa1d39980874b9e
+oid sha256:b15160cdd8ce37d0be1caaa8865d0cf7d2553695f5a5b24ab7ab681ca46fe5cc
 size 6287360


### PR DESCRIPTION
Update CSME to the version from CFL-S/H IPU 24.1 (Kit 792171).

(I couldn't find a 2024-03 IPU/BKC like everything else.)

Test:

- CSME can be enabled/disabled via coreboot CMOS option
- System boots
- System completes suspend cycle
- System powers off when shutdown