### PR TITLE
cml-u: Update CSME to 14.1.74.2355v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ features apply to your model and firmware version, see the
 - Fixed unlock prompt showing when system is already unlocked
 - lemp13-b: Added support for units with 5600 MT/s soldered RAM
 - cml-h: Updated CSME to 14.1.74.2355v6 (14.1.72.2287)
+- cml-u: Updated CSME to 14.1.74.2355v6 (14.1.74.2373)
 
 ## 2024-05-28
 

--- a/models/darp6/README.md
+++ b/models/darp6/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/darp6
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.74.2373

--- a/models/darp6/me.rom
+++ b/models/darp6/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bb8ca44af9bd812478cadbe0ef7a1175d9426de57320679f3475a07f3fa7ab9
+oid sha256:d242789ceeae275b429853b9d23c46fe1f581dd3a93d12815be9dde5e5bd0570
 size 4190208

--- a/models/galp4/README.md
+++ b/models/galp4/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/galp4
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.74.2373

--- a/models/galp4/me.rom
+++ b/models/galp4/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b54e9d1579c53c656c89c57360518cf6f8b07680e8639b65e10cb1af4a33af8
+oid sha256:bcba2088fc1ef63cc7d1e0c907642717bd727ae4d4e26c274c84ada9a48cdfe9
 size 4190208

--- a/models/lemp9/README.md
+++ b/models/lemp9/README.md
@@ -11,4 +11,4 @@ https://system76.com/guides/lemp9
   - HAP: false
 - [ME](./me.rom)
   - Size: 4092 KB
-  - Version: 14.0.60.1807
+  - Version: 14.1.74.2373

--- a/models/lemp9/me.rom
+++ b/models/lemp9/me.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e439f76d53ab69b801bfaf54b4ee81005e0c577cd6e116bdb2b4893a2d00547
+oid sha256:7814ba36644fe26c98dbf366febf11bd637cd52484f75288f725d85f462d70a8
 size 4190208


### PR DESCRIPTION
Update CSME to the version from CML-U IPU 24.3 (Kit 813939).

Test:

- CSME can be enabled/disabled via coreboot CMOS option
- System boots
- System completes suspend cycle
- System powers off when shutdown