### PR TITLE
ec: Fix touchpad in PS/2 mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ features apply to your model and firmware version, see the
 - mtl: Updated FSP to D.0.A8.20
 - adl: Fixed USB 3.0 hubs in Type-C ports
 - rpl: Fixed USB 3.0 hubs in Type-C ports
+- Fixed touchpad in PS/2 mode
 
 ## 2024-05-17
 


### PR DESCRIPTION
Clear PS/2 status to prevent data for writes being detected on reads, which was causing drivers to stop working.