### PR TITLE
add nix-shell file for building with nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,40 @@
+# shell.nix
+
+# NOTE we need mkShellNoCC
+# mkShell would add the regular gcc, which has no ada (gnat)
+# https://github.com/NixOS/nixpkgs/issues/142943
+
+with import <nixpkgs> { };
+mkShellNoCC {
+  buildInputs = [
+    ccache
+    gnat12 # gcc with ada
+    #gnatboot # gnat1
+    git
+    git-lfs
+    python3
+    ncurses # make menuconfig
+    m4 flex bison # Generate flashmap descriptor parser
+    #clang
+    zlib
+    #acpica-tools # iasl
+    pkg-config
+    openssl
+    rustup
+    qemu # test the image
+  ];
+  shellHook = ''
+    # TODO remove?
+    NIX_LDFLAGS="$NIX_LDFLAGS -lncurses"
+
+    # Setup Git repo
+    git lfs install
+    git lfs pull
+    git submodule update --init --recursive --checkout --progress
+
+    # coreboot sdk
+    make -C coreboot CPUS="$(nproc)" crossgcc-i386
+    make -C coreboot CPUS="$(nproc)" crossgcc-x64
+    make -C coreboot gitconfig
+  '';
+}


### PR DESCRIPTION
Once you enter `shell` in the firmware-open repo it will basically run though the install-deps and coreboot-sdk scripts so that you can build your firmware right after it is done. I tested with the qemu firmware test to make sure that it did work. 

I'm going to test on Pop!_OS next as this was done on NixOS to be sure that I have all of the depends. 