### PR TITLE
Update container file

### DIFF
--- a/containers/firmware-open/Containerfile
+++ b/containers/firmware-open/Containerfile
@@ -1,9 +1,11 @@
 # Container for building System76 Open Firmware
 
-ARG CONTAINER_IMAGE="docker.io/library/debian:trixie-20240701-slim"
+# NOTE: The repository is specified in the image name to make it explicit
+# which source is being trusted to provide the image.
+ARG CONTAINER_IMAGE="docker.io/library/debian:bookworm-20241016-slim"
 
 ARG COREBOOT_REPO="https://github.com/coreboot/coreboot.git"
-ARG COREBOOT_COMMIT="24.02"
+ARG COREBOOT_COMMIT="24.08"
 
 ARG SDCC_REPO="https://svn.code.sf.net/p/sdcc/code"
 ARG SDCC_REV="14648"
@@ -17,8 +19,8 @@ ARG COREBOOT_COMMIT
 ARG COREBOOT_REPO
 WORKDIR /tmp
 
-RUN apt-get --quiet update && \
-    apt-get --quiet install --no-install-recommends --assume-yes \
+RUN apt-get --quiet update \
+    && apt-get --quiet install --no-install-recommends --assume-yes \
         bash \
         bison \
         bzip2 \
@@ -38,17 +40,17 @@ RUN apt-get --quiet update && \
         python3 \
         tar \
         xz-utils \
-        zlib1g-dev && \
-    apt-get clean
+        zlib1g-dev \
+    && apt-get clean
 
-RUN git clone ${COREBOOT_REPO} && \
-    cd coreboot && \
-    git checkout ${COREBOOT_COMMIT}
+RUN git clone ${COREBOOT_REPO} \
+    && cd coreboot \
+    && git checkout ${COREBOOT_COMMIT}
 
 RUN make -C coreboot \
         CPUS=$(nproc) BUILD_LANGUAGES=ada,c,c++ DEST=/opt/xgcc \
-        crossgcc-i386 crossgcc-x64 && \
-    rm -rf coreboot
+        crossgcc-i386 crossgcc-x64 \
+    && rm -rf coreboot
 
 # Build SDCC toolchain
 FROM ${CONTAINER_IMAGE} as sdcc-build
@@ -57,8 +59,8 @@ ARG SDCC_REV
 ARG SDCC_VERSION
 WORKDIR /tmp
 
-RUN apt-get --quiet update && \
-    apt-get --quiet install --no-install-recommends --assume-yes \
+RUN apt-get --quiet update \
+    && apt-get --quiet install --no-install-recommends --assume-yes \
         autoconf \
         automake \
         bison \
@@ -69,8 +71,8 @@ RUN apt-get --quiet update && \
         libboost-dev \
         make \
         subversion \
-        zlib1g-dev && \
-    apt-get clean
+        zlib1g-dev \
+    && apt-get clean
 
 RUN svn checkout \
     --depth infinity \
@@ -79,8 +81,8 @@ RUN svn checkout \
     sdcc
 
 # Only the MCS-51 port is needed.
-RUN cd sdcc && \
-    sh ./configure \
+RUN cd sdcc \
+    && sh ./configure \
         --disable-z80-port \
         --disable-z180-port \
         --disable-r2k-port \
@@ -104,9 +106,9 @@ RUN cd sdcc && \
         --disable-ucsim \
         --disable-sdcdb \
         --disable-non-free \
-        --prefix= && \
-    make -j $(nproc) && \
-    make install DESTDIR=/opt/sdcc
+        --prefix= \
+    && make -j $(nproc) \
+    && make install DESTDIR=/opt/sdcc
 
 # Set up environment for building firmware-open
 FROM ${CONTAINER_IMAGE}
@@ -120,8 +122,8 @@ ENV SDCC_REV "${SDCC_REV}"
 ENV SDCC_VERSION "${SDCC_VERSION}"
 ENV PATH "$XGCCPATH:$SDCC_PATH/bin:$PATH"
 
-RUN apt-get --quiet update && \
-    apt-get --quiet install --no-install-recommends --assume-yes \
+RUN apt-get --quiet update \
+    && apt-get --quiet install --no-install-recommends --assume-yes \
         bash \
         binutils \
         ca-certificates \
@@ -144,26 +146,35 @@ RUN apt-get --quiet update && \
         pkgconf \
         python-is-python3 \
         python3 \
-        rustup \
         shellcheck \
         uncrustify \
         uuid-dev \
         xxd \
     && apt-get clean
 
-RUN rustup toolchain install \
+# TODO: Use distro rustup package when available (Trixie).
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable
+
+# XXX: rustup 1.27 does not recognize toolchain if preceding option specifies
+# a comma seprates list as an argument with a space.
+# Ref: https://github.com/rust-lang/rustup/issues/4073
+RUN . "${HOME}/.cargo/env" \
+    && rustup toolchain install \
         --no-self-update \
         --target x86_64-unknown-linux-gnu,x86_64-unknown-uefi \
         --profile minimal \
-        --component clippy,rustfmt \
+        --component=clippy,rustfmt \
         ${RUST_TOOLCHAIN}
 
 # XXX: firmware-setup is stuck on 2023-01-21
-RUN rustup toolchain install \
+# Ref: https://github.com/system76/firmware-setup/issues/47
+RUN . "${HOME}/.cargo/env" \
+    && rustup toolchain install \
         --no-self-update \
         --target x86_64-unknown-uefi \
         --profile minimal \
-        --component clippy,rustfmt \
+        --component=clippy,rustfmt \
         nightly-2023-01-21
 
 WORKDIR /workspace


### PR DESCRIPTION
- Change image from trixie-20240701-slim to bookworm-20241016-slim
  - unstable doesn't keep GNAT in sync with GCC, which causes problems when compiling coreboot SDK
- Update coreboot SDK from 24.02 to 24.08
  - Match coreboot submodule base
- Add workaround for bug in rustup 1.27
- Add link to firmware-setup issue to track toolchain blocker
- Put `&&` at beginning of all chained commands for consistency, and to reduce the diff if commands are added/removed

Locally built image is 3.77 GiB.