### PR TITLE
ci: Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: NONE
+
+name: CI
+on:
+  push:
+    branches-ignore:
+    - 'wip/*'
+  pull_request:
+
+env:
+  XGCC_DIR: "/opt/xgcc"
+  XGCCPATH: "/opt/xgcc/bin"
+
+jobs:
+  toolchain:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    outputs:
+      models: ${{ steps.model-matrix.outputs.models }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        lfs: true
+        submodules: recursive
+        fetch-tags: true
+        fetch-depth: 0
+
+    - name: Get coreboot toolchain
+      id: get_coreboot_toolchain
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.XGCC_DIR }}
+        key: coreboot-${{ hashFiles('coreboot/util/crossgcc/sum/*') }}
+
+    - name: Build coreboot toolchain
+      if: steps.get_coreboot_toolchain.outputs.cache-hit != 'true'
+      run: ./scripts/coreboot-sdk.sh DEST=$XGCC_DIR
+
+    - name: Generate model matrix
+      id: model-matrix
+      run: |
+        FIRMWARE_MODELS=$(find models/ -maxdepth 1 -mindepth 1 -type d -printf "%f\n" | jq -cRSs 'split("\n")[:-1]')
+        echo "models=$FIRMWARE_MODELS" >> $GITHUB_OUTPUT
+
+  build:
+    runs-on: ubuntu-24.04
+    needs: toolchain
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        model: ${{ fromJSON(needs.toolchain.outputs.models) }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        lfs: true
+        submodules: recursive
+        fetch-tags: true
+        fetch-depth: 0
+
+    - name: Fix coreboot submodules
+      working-directory: ./coreboot
+      run: git submodule update --init --checkout --recursive --force
+
+    - name: Get coreboot toolchain
+      id: get_coreboot_toolchain
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.XGCC_DIR }}
+        key: coreboot-${{ hashFiles('coreboot/util/crossgcc/sum/*') }}
+        fail-on-cache-miss: true
+
+    - name: Install deps
+      run: |
+        ./scripts/install-deps.sh
+        ./scripts/install-rust.sh
+        pushd ec; ./scripts/deps.sh; popd
+
+    - name: Build firmware
+      run: ./scripts/build.sh "${{ matrix.model }}"
+
+    #- name: Upload artifacts
+    #  if: github.ref == 'refs/heads/master'
+    #  uses: actions/upload-artifact@v4
+    #  with:
+    #    name: ${{ matrix.model }}-${{ github.sha }}
+    #    path: build/
+    #    retention-days: 30

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,9 +1,12 @@
 # Building
 
-Dependencies can be installed with the provided script.
+Dependencies can be installed with the provided scripts.
 
 ```
 ./scripts/install-deps.sh
+./scripts/install-rust.sh
+./scripts/coreboot-sdk.sh
+pushd ec; ./scripts/deps.sh; popd
 ```
 
 If rustup was installed for the first time, it will be required to source the

--- a/scripts/coreboot-sdk.sh
+++ b/scripts/coreboot-sdk.sh
@@ -61,6 +61,8 @@ else
     exit 1
 fi
 
-make -C coreboot CPUS="$(nproc)" crossgcc-i386
-make -C coreboot CPUS="$(nproc)" crossgcc-x64
-make -C coreboot gitconfig
+make -C coreboot \
+    crossgcc-x64 \
+    crossgcc-i386 \
+    CPUS="$(nproc)" \
+    "${@}"

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -5,99 +5,96 @@
 
 set -eE
 
-msg() {
-  echo -e "\x1B[1m$*\x1B[0m" >&2
-}
-
-trap 'msg "\x1B[31mFailed to install dependencies!"' ERR
-
 . /etc/os-release
-
-msg "Installing system build dependencies"
 if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
-  sudo apt-get --quiet update
-  sudo apt-get --quiet install \
-    --no-install-recommends \
-    --assume-yes \
-    build-essential \
-    ccache \
-    cmake \
-    curl \
-    dosfstools \
-    flashrom \
-    git-lfs \
-    libncurses-dev \
-    libssl-dev \
-    libudev-dev \
-    mtools \
-    parted \
-    pkgconf \
-    python-is-python3 \
-    uuid-dev \
-    zlib1g-dev
+    sudo apt-get --quiet update
+    sudo apt-get --quiet install --no-install-recommends --assume-yes \
+        bison \
+        build-essential \
+        bzip2 \
+        ca-certificates \
+        ccache \
+        cmake \
+        curl \
+        dosfstools \
+        flashrom \
+        flex \
+        g++ \
+        gcc \
+        git-lfs \
+        gnat \
+        libncurses-dev \
+        libnss3-dev \
+        libssl-dev \
+        libudev-dev \
+        make \
+        mtools \
+        parted \
+        patch \
+        pkgconf \
+        python-is-python3 \
+        tar \
+        uuid-dev \
+        xz-utils \
+        zlib1g-dev
 elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
-  sudo dnf group install c-development
-  sudo dnf install \
-    --assumeyes \
-    ccache \
-    cmake \
-    curl \
-    dosfstools \
-    flashrom \
-    git-lfs \
-    libuuid-devel \
-    mtools \
-    ncurses-devel \
-    openssl-devel \
-    parted \
-    patch \
-    python-unversioned-command \
-    python3 \
-    systemd-devel \
-    zlib-devel
+    sudo dnf group install c-development
+    sudo dnf install --assumeyes \
+        bison \
+        bzip2 \
+        ca-certificates \
+        ccache \
+        cmake \
+        curl \
+        dosfstools \
+        flashrom \
+        flex \
+        gcc \
+        gcc-c++ \
+        gcc-gnat \
+        git-lfs \
+        libuuid-devel \
+        make \
+        mtools \
+        ncurses-devel \
+        nss-devel \
+        openssl-devel \
+        parted \
+        patch \
+        python-unversioned-command \
+        python3 \
+        rustup \
+        systemd-devel \
+        tar \
+        xz \
+        zlib-devel
 elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
-  sudo pacman -S \
-    --noconfirm \
-    ccache \
-    cmake \
-    curl \
-    dosfstools \
-    flashrom \
-    git-lfs \
-    mtools \
-    ncurses \
-    parted \
-    patch \
-    python \
-    systemd-libs
+    sudo pacman -S --noconfirm \
+        bison \
+        bzip2 \
+        ca-certificates \
+        ccache \
+        cmake \
+        curl \
+        dosfstools \
+        flashrom \
+        flex \
+        gcc \
+        gcc-ada \
+        git-lfs \
+        make \
+        mtools \
+        ncurses \
+        nss \
+        parted \
+        patch \
+        python \
+        rustup \
+        systemd-libs \
+        tar \
+        xz \
+        zlib
 else
-  msg "Unknown system ID: ${ID}"
-  msg "Please add support for your distribution to: $0"
-  exit 1
+    echo "unsupported host: ${ID}"
+    exit 1
 fi
-
-# Don't run on Jenkins
-if [ -z "${CI}" ]; then
-    msg "Installing GIT LFS hooks"
-    git lfs install
-
-    msg "Downloading GIT LFS artifacts"
-    git lfs pull
-fi
-
-msg "Initializing submodules"
-git submodule update --init --recursive --checkout --progress
-
-msg "Building coreboot toolchains"
-./scripts/coreboot-sdk.sh
-
-msg "Installing Rust toolchain and components"
-./scripts/install-rust.sh
-
-msg "Installing EC dependencies"
-pushd ec
-./scripts/deps.sh
-popd
-
-msg "\x1B[32mSuccessfully installed dependencies"
-echo "Ready to run ./scripts/build.sh [model]" >&2

--- a/scripts/install-rust.sh
+++ b/scripts/install-rust.sh
@@ -8,20 +8,18 @@
 
 set -Ee
 
-RUSTUP_NEW_INSTALL=0
-
-# NOTE: rustup is used to allow multiple toolchain installations.
 if ! command -v rustup >/dev/null 2>&1; then
-    RUSTUP_NEW_INSTALL=1
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-        | sh -s -- -y --default-toolchain stable
+    if command -v rustup-init >/dev/null 2>&1; then
+        rustup-init -y \
+            --default-toolchain stable \
+            --profile minimal \
+            --no-update-default-toolchain
+    else
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain stable
+    fi
 
     . "${HOME}/.cargo/env"
 fi
 
 rustup show active-toolchain || rustup toolchain install
-
-if [ "$RUSTUP_NEW_INSTALL" = "1" ]; then
-    printf "\e[33m>> rustup was just installed. Ensure cargo is on the PATH with:\e[0m\n"
-    printf "    source ~/.cargo/env\n\n"
-fi


### PR DESCRIPTION
TODO:

- Determine cache storage usage/cost
  - coreboot toolchain is using 160 MB, and apparently there's 10 GB available
- Determine artifact storage usage/cost
  - disabled upload-artifact for now because it's going to be a lot of space
- Replace script in private firmware repo for downloading build artifacts when staging updates
  - depends on uploading artifacts
- Investigate reducing CI time, esp. on cloning all the submodules and installing build dependencies
- Limit the models built by default to not hit concurrency limit?
  - But would want a way to manually trigger a build by specifying models like Jenkins currently does