### PR TITLE
scripts: Split creating USB image to separate script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,7 +32,6 @@ mkdir -p "${BUILD}"
 
 UEFIPAYLOAD="${BUILD}/UEFIPAYLOAD.fd"
 COREBOOT="${BUILD}/firmware.rom"
-USB="${BUILD}/usb.img"
 EDK2_ARGS=(
     -D SHELL_TYPE=NONE
     -D SOURCE_DEBUG_ENABLE=FALSE
@@ -89,32 +88,6 @@ then
         ./scripts/_build/ec.sh \
         "${MODEL_DIR}/ec.config" \
         "${BUILD}/ec.rom"
-fi
-
-if [ "${MODEL}" != "qemu" ]
-then
-    # Rebuild firmware-update
-    export BASEDIR="system76_${MODEL}_${VERSION}"
-    pushd apps/firmware-update >/dev/null
-      make "build/x86_64-unknown-uefi/boot.img"
-      cp -v "build/x86_64-unknown-uefi/boot.img" "${USB}.partial"
-    popd >/dev/null
-
-    # Copy firmware to USB image
-    mmd -i "${USB}.partial@@1M" "::${BASEDIR}/firmware"
-    mcopy -v -i "${USB}.partial@@1M" "${COREBOOT}" "::${BASEDIR}/firmware/firmware.rom"
-    if [ -e "${BUILD}/ec.rom" ]
-    then
-        mcopy -v -i "${USB}.partial@@1M" "${BUILD}/ec.rom" "::${BASEDIR}/firmware/ec.rom"
-    elif [ -e "${MODEL_DIR}/ec.rom" ]
-    then
-        mcopy -v -i "${USB}.partial@@1M" "${MODEL_DIR}/ec.rom" "::${BASEDIR}/firmware/ec.rom"
-    fi
-    if [ -e "${MODEL_DIR}/uecflash.efi" ]
-    then
-        mcopy -v -i "${USB}.partial@@1M" "${MODEL_DIR}/uecflash.efi" "::${BASEDIR}/firmware/uecflash.efi"
-    fi
-    mv -v "${USB}.partial" "${USB}"
 fi
 
 echo "Built '${VERSION}' for '${MODEL}'"

--- a/scripts/usb.sh
+++ b/scripts/usb.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Create a USB image file that can be written to a USB flash drive to update
+# firmware on another computer.
+
+if [ -z "$1" ]; then
+    echo "$0 <model>" >&2
+    exit 1
+fi
+MODEL="$1"
+
+if [ "${MODEL}" = "qemu" ]; then
+    echo "can't build USB image for flashing QEMU" >&2
+    exit 1
+fi
+
+if [ ! -d "models/${MODEL}" ]; then
+    echo "model '${MODEL}' not found" >&2
+    exit 1
+fi
+MODEL_DIR="$(realpath "models/${MODEL}")"
+
+DATE="$(git show --format="%cd" --date="format:%Y-%m-%d" --no-patch --no-show-signature)"
+REV="$(git describe --always --dirty --abbrev=7)"
+VERSION="${DATE}_${REV}"
+
+BUILD="$(realpath "build/${MODEL}")"
+if [ ! -e "${BUILD}/firmware.rom" ]; then
+    echo "'${BUILD}/firmware.rom' not found" >&2
+    exit 1
+fi
+
+USB="${BUILD}/usb.img"
+
+# Rebuild firmware-update
+export BASEDIR="system76_${MODEL}_${VERSION}"
+make -C apps/firmware-update "build/x86_64-unknown-uefi/boot.img"
+cp -v "apps/firmware-update/build/x86_64-unknown-uefi/boot.img" "${USB}.partial"
+
+# Copy firmware to USB image
+mmd -i "${USB}.partial@@1M" "::${BASEDIR}/firmware"
+mcopy -v -i "${USB}.partial@@1M" "${COREBOOT}" "::${BASEDIR}/firmware/firmware.rom"
+if [ -e "${BUILD}/ec.rom" ]; then
+    mcopy -v -i "${USB}.partial@@1M" "${BUILD}/ec.rom" "::${BASEDIR}/firmware/ec.rom"
+elif [ -e "${MODEL_DIR}/ec.rom" ]; then
+    mcopy -v -i "${USB}.partial@@1M" "${MODEL_DIR}/ec.rom" "::${BASEDIR}/firmware/ec.rom"
+fi
+if [ -e "${MODEL_DIR}/uecflash.efi" ]; then
+    mcopy -v -i "${USB}.partial@@1M" "${MODEL_DIR}/uecflash.efi" "::${BASEDIR}/firmware/uecflash.efi"
+fi
+mv -v "${USB}.partial" "${USB}"


### PR DESCRIPTION
The USB image is not a required output, but becomes half of the total size of the build artifacts as it creates copies of the firmware images. Move the logic to a separate script so that CI will not contain it, but users can create the image after building the firmware.

    ./scripts/build.sh <model>
    ./scripts/usb.sh <model>

Reduces the size of the ZIP archive created by Jenkins by ~50%.

```
$ ls -lh build/darp10/
total 90M
-rw-r--r--. 1 tcrawford tcrawford 256K Feb 28 15:40 ec.rom
-rw-r--r--. 1 tcrawford tcrawford  32M Feb 28 15:40 firmware.rom
-rw-r--r--. 1 tcrawford tcrawford 8.0M Feb 28 15:40 UEFIPAYLOAD.fd
-rw-r--r--. 1 tcrawford tcrawford  49M Feb 28 15:40 usb.img
```