### PR TITLE
ci: Speed up toolchain job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        lfs: true
-        submodules: recursive
-        fetch-tags: true
+        filter: tree:0
         fetch-depth: 0
+
+    - name: Checkout coreboot
+      run: git submodule update --init --checkout --force coreboot
 
     - name: Check coreboot toolchain exists
       id: get_coreboot_toolchain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,12 +26,13 @@ jobs:
         fetch-tags: true
         fetch-depth: 0
 
-    - name: Get coreboot toolchain
+    - name: Check coreboot toolchain exists
       id: get_coreboot_toolchain
       uses: actions/cache@v4
       with:
         path: ${{ env.XGCC_DIR }}
         key: coreboot-${{ hashFiles('coreboot/util/crossgcc/sum/*') }}
+        lookup-only: true
 
     - name: Build coreboot toolchain
       if: steps.get_coreboot_toolchain.outputs.cache-hit != 'true'


### PR DESCRIPTION
- Only checkout the coreboot submodule for building the toolchain
- Don't restore the cache when checking if we need to build the toolchain

Reduces toolchain job time from ~2.5m to ~20s (when it doesn't need to be rebuilt).