### PR TITLE
scripts: Use coreboot mirror for building toolchain

### DIFF
--- a/scripts/coreboot-sdk.sh
+++ b/scripts/coreboot-sdk.sh
@@ -61,8 +61,12 @@ else
     exit 1
 fi
 
+BUILDGCC_OPTIONS+="--mirror"
+export BUILDGCC_OPTIONS
+
 make -C coreboot \
     crossgcc-x64 \
     crossgcc-i386 \
     CPUS="$(nproc)" \
+    BUILDGCC_OPTIONS="${BUILDGCC_OPTIONS}" \
     "${@}"


### PR DESCRIPTION
The NASM website has been offline for days. Use the coreboot mirror to fix building the toolchain.