### PR TITLE
jenkins: Fix string concat

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,15 +7,15 @@
 // - Pipeline (https://plugins.jenkins.io/workflow-aggregator/)
 // - Slack Notification (https://plugins.jenkins.io/slack/)
 
-def all_models = "addw2 addw3 addw4 "
-    + "bonw14 bonw15 bonw15-b "
-    + "darp5 darp6 darp7 darp8 darp9 darp10 darp10-b darp11 darp11-b "
-    + "galp3-c galp4 galp5 galp6 galp7 "
-    + "gaze15 gaze16-3050 gaze16-3060 gaze16-3060-b gaze16-3050 gaze16-3060-b gaze17-3050 gaze17-3060-b gaze18 "
-    + "lemp9 lemp10 lemp11 lemp12 lemp13 lemp13-b "
-    + "meer9 "
-    + "oryp5 oryp6 oryp7 oryp8 oryp9 oryp10 oryp11 oryp12 "
-    + "serw13 "
+def all_models = "addw2 addw3 addw4 " +
+    "bonw14 bonw15 bonw15-b " +
+    "darp5 darp6 darp7 darp8 darp9 darp10 darp10-b darp11 darp11-b " +
+    "galp3-c galp4 galp5 galp6 galp7 " +
+    "gaze15 gaze16-3050 gaze16-3060 gaze16-3060-b gaze16-3050 gaze16-3060-b gaze17-3050 gaze17-3060-b gaze18 " +
+    "lemp9 lemp10 lemp11 lemp12 lemp13 lemp13-b " +
+    "meer9 " +
+    "oryp5 oryp6 oryp7 oryp8 oryp9 oryp10 oryp11 oryp12 " +
+    "serw13 "
 
 void setBuildStatus(String state, String message) {
     // FIXME: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation


### PR DESCRIPTION
Does Groovy parse the running script line-by-line? Apparently, `+` must exist on the starting line for it to know that the next line is a continuation.

Fixes: 99ffbf9bdb60 ("jenkins: Add darp11, darp11-b")