### PR TITLE
Containerfile: update

### DIFF
--- a/containers/Makefile
+++ b/containers/Makefile
@@ -14,9 +14,14 @@ PODMAN := $(shell command -v podman)
 
 CONTAINER_TAG := latest
 
+COREBOOT_REPO ?= https://github.com/coreboot/coreboot.git
+COREBOOT_COMMIT ?= 24.08
+
 .PHONY: firmware-open
 firmware-open:
 	$(PODMAN) build \
 		--tag system76/$@:$(CONTAINER_TAG) \
+		--build-arg COREBOOT_REPO=$(COREBOOT_REPO) \
+		--build-arg COREBOOT_COMMIT=$(COREBOOT_COMMIT) \
 		--file Containerfile \
 		$@

--- a/containers/firmware-open/Containerfile
+++ b/containers/firmware-open/Containerfile
@@ -120,7 +120,8 @@ ENV XGCCPATH "/opt/xgcc/bin"
 ENV SDCC_PATH "/opt/sdcc"
 ENV SDCC_REV "${SDCC_REV}"
 ENV SDCC_VERSION "${SDCC_VERSION}"
-ENV PATH "$XGCCPATH:$SDCC_PATH/bin:$PATH"
+ENV CARGO_BIN_PATH "/root/.cargo/bin"
+ENV PATH "$CARGO_BIN_PATH:$XGCCPATH:$SDCC_PATH/bin:$PATH"
 
 RUN apt-get --quiet update \
     && apt-get --quiet install --no-install-recommends --assume-yes \
@@ -156,15 +157,11 @@ RUN apt-get --quiet update \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable
 
-# XXX: rustup 1.27 does not recognize toolchain if preceding option specifies
-# a comma seprates list as an argument with a space.
-# Ref: https://github.com/rust-lang/rustup/issues/4073
-RUN . "${HOME}/.cargo/env" \
-    && rustup toolchain install \
+RUN rustup toolchain install \
         --no-self-update \
         --target x86_64-unknown-linux-gnu,x86_64-unknown-uefi \
         --profile minimal \
-        --component=clippy,rustfmt \
+        --component clippy,rustfmt \
         ${RUST_TOOLCHAIN}
 
 WORKDIR /workspace


### PR DESCRIPTION
Context:
- Once again, I decided to try experimenting with fan curves on my `addw4`, I noticed that there is a Containerfile, which is very handy
- I needed to modify the scripts a bit to achieve parity with the native building (and fix `cargo` not found error)

Can now be called with passing custom coreboot revision parameters:
```shell
COREBOOT_REPO=https://github.com/system76/coreboot \
COREBOOT_COMMIT=system76 \
	make -C containers
```




