### PR TITLE
edk2: Fixes for PCI enumeration and GOP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ features apply to your model and firmware version, see the
 - Improved touchpad PS/2 compatibility
 - Updated coreboot to 26.03
 - Updated Intel microcode to microcode-20260227
+- Fixed GraphicsOutputDxe for MTL+
+- Fixed PCI enumeration in EDK2
+- Fixed adding BGRT to ACPI table
 
 ## 2025-11-11
 


### PR DESCRIPTION
- Fix PciHostBridgeLib, remove deprecated Pci*NoEnumerationDxe
- Fix GraphicsOutputDxe for MTL+
- Remove BGRT hack
- brotli: Disable Wformat-overflow
  - Fixes building with newer versions of GCC
