### PR TITLE
Add cd command to move into location of `Makefile`

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -12,7 +12,7 @@ Dependencies can be installed with the provided scripts.
 ./scripts/install-deps.sh
 ./scripts/install-rust.sh
 ./scripts/coreboot-sdk.sh
-./ec/scripts/deps.sh
+cd ec; ./scripts/deps.sh; cd ../
 ```
 
 If rustup was installed for the first time, it will be required to source the


### PR DESCRIPTION
This is a minor change to the documentation here: https://github.com/system76/firmware-open/blob/master/docs/building.md.

The `firmware-open/ec/scripts/deps.sh` file tries to run `make git-config` where `git-config` is defined in `firmware-open/ec/`. According to the current documentation, running `./ec/scripts/deps.sh` should work (running from `firmware-open/`) but instead leads to a `make: *** No rule to make target 'git-config'.  Stop.` error. By adding a `cd` then the `deps.sh` file can find the `Makefile`.