### PR TITLE
Remove scripts/coreboot-sdk.h crossgcc mirror sources

### DIFF
--- a/scripts/coreboot-sdk.sh
+++ b/scripts/coreboot-sdk.sh
@@ -61,12 +61,8 @@ else
     exit 1
 fi
 
-BUILDGCC_OPTIONS+="--mirror"
-export BUILDGCC_OPTIONS
-
 make -C coreboot \
     crossgcc-x64 \
     crossgcc-i386 \
     CPUS="$(nproc)" \
-    BUILDGCC_OPTIONS="${BUILDGCC_OPTIONS}" \
     "${@}"


### PR DESCRIPTION
This removes the scripts/coreboot-sdk.h crossgcc build forcing the usage of coreboot's source mirrors, with BUILDGCC_OPTIONS='--mirror'. Notably, the coreboot.org source archive mirror URLs have been all serving 403 Forbidden notices for many days, without any external notice apparent. Also beneficially, BUILDGCC_OPTIONS can now be controlled from the parent's side, as any other env var.