### PR TITLE
Fix Debian support in scripts

### DIFF
--- a/scripts/coreboot-sdk.sh
+++ b/scripts/coreboot-sdk.sh
@@ -39,7 +39,7 @@ elif [ "$ID" = "fedora" ] || [[ "$ID_LIKE" =~ "fedora" ]]; then
         tar \
         xz \
         zlib-devel
-elif [ "$ID" = "ubuntu" ] || [[ "$ID_LIKE" =~ "debian" ]]; then
+elif [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ] || [[ "$ID_LIKE" =~ "debian" ]]; then
     sudo apt-get --quiet update
     sudo apt-get --quiet install --no-install-recommends --assume-yes \
         bison \

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -33,6 +33,7 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
         patch \
         pkgconf \
         python-is-python3 \
+        rustup \
         tar \
         uuid-dev \
         xz-utils \


### PR DESCRIPTION
This updates the `scripts/coreboot-sdk.sh` dependency-install branch for Ubuntu to also work for Debian, which it does.

Also, now that Debian Stable (Trixie) includes a `rustup` package, this adds that to the `scripts/install-deps.sh` branch for Debian, in line with other supported distros.