### PR TITLE
Update coreboot to 26.03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ features apply to your model and firmware version, see the
 
 - Fixed PE32 alignment of Rust UEFI modules
 - Improved touchpad PS/2 compatibility
+- Updated coreboot to 26.03
+- Updated Intel microcode to microcode-20260227
 
 ## 2025-11-11
 


### PR DESCRIPTION
- https://github.com/system76/coreboot/pull/269

### TODO

- [ ] Verify HDA works on meer9 with new verb table implementation
- [ ] Verify upstreamed dTBT driver works with PCIe hotplug
  - Update TBT GPIOs
    - Set `FORCE_POWER` high
    - Set `RTD3_PWR_EN` high
    - Set `PERST#` high
    - Set `RESET#` high?
- [ ] Check what happened to lemp13 GPIO config; apply `gpio.c` from `system76-25.03` if necessary