### PR TITLE
fix broken link to mega2560 in `docs/adding-a-new-board.md`

### DIFF
--- a/docs/adding-a-new-board.md
+++ b/docs/adding-a-new-board.md
@@ -110,5 +110,5 @@ READMEs.
 
 [external-programmer]: ./flashing.md#external-programmer
 [intel-microcode]: https://github.com/system76/intel-microcode
-[mega2560]: https://github.com/system76/ec/blob/master/doc/mega2560.md
+[mega2560]: https://github.com/system76/ec/blob/master/docs/mega2560.md
 [smart-amp]: https://github.com/system76/smart-amp


### PR DESCRIPTION
It was just missing an `s`